### PR TITLE
fix(security): Update go-resty to v2.11.0 - CVE-2023-45286

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -15,7 +15,7 @@ require (
 
 require (
 	github.com/go-logr/logr v1.3.0
-	github.com/go-resty/resty/v2 v2.10.0
+	github.com/go-resty/resty/v2 v2.11.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/stretchr/testify v1.8.4
 	go.uber.org/zap v1.26.0


### PR DESCRIPTION
## Security Fix

This PR updates  from v2.10.0 to v2.11.0 to address a security vulnerability.

### Vulnerability Details
- **CVE**: CVE-2023-45286
- **GHSA**: [GHSA-xwh9-gc39-5298](https://github.com/advisories/GHSA-xwh9-gc39-5298)
- **Severity**: Medium (CVSS 5.9)
- **Summary**: HTTP request body disclosure vulnerability due to race condition in sync.Pool usage

### Impact
A race condition in go-resty can result in HTTP request body disclosure across requests when:
- Request retries are enabled
- A retry occurs
- The sync.Pool.Put is called with the same *bytes.Buffer more than once

This could potentially leak sensitive data from one request to another unrelated request.

### Fix
Updated to go-resty v2.11.0 which includes the fix for this vulnerability.

### Testing
- [ ] CI tests pass
- [ ] No breaking changes in API usage

Closes #1 (Dependabot security alert)