### PR TITLE
ci(deps): consolidate GitHub Actions bumps (codeql v4, setup-python v6, upload-artifact v5, setup-helm v4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           
@@ -103,7 +103,7 @@ jobs:
           output: 'trivy-results.sarif'
           
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         # Dependabot/fork PRs run with a read-only token and cannot upload SARIF;
         # keep the job green there while still uploading on push to protected branches.
         if: always()
@@ -112,7 +112,7 @@ jobs:
           sarif_file: 'trivy-results.sarif'
           
       - name: Set up Python for security scan
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           
@@ -150,7 +150,7 @@ jobs:
           args: --timeout=5m
           
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           
@@ -193,7 +193,7 @@ jobs:
           go build -o ../bin/api-server ./cmd/api-server
           
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           
@@ -204,7 +204,7 @@ jobs:
           python -m build
           
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: build-artifacts
           path: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         queries: security-extended,security-and-quality
@@ -45,6 +45,6 @@ jobs:
         go build ./...
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
             ./cmd/api-server
             
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v5
         with:
           name: binaries-${{ matrix.os }}-${{ matrix.arch }}
           path: dist/*
@@ -96,7 +96,7 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           
@@ -171,7 +171,7 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Install Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v4
         
       - name: Package Helm chart
         run: |

--- a/docs/superpowers/specs/2026-05-29-pr-47-github-actions-deps-design.md
+++ b/docs/superpowers/specs/2026-05-29-pr-47-github-actions-deps-design.md
@@ -1,0 +1,48 @@
+# Design (PR #47): Consolidated GitHub Actions dependency bumps
+
+- Date: 2026-05-29
+- Status: Implemented
+- Supersedes Dependabot PRs: #39 (codeql-action), #34 (setup-python), #41 (upload-artifact),
+  #15 (setup-helm). Also closes obsolete #9 (codecov-action, already at v5).
+
+## Problem statement and scope
+
+Several Dependabot PRs bump GitHub Actions used in the workflows. Consolidate the still-relevant
+ones into a single change and close the obsolete one.
+
+Scope: `.github/workflows/ci.yml`, `.github/workflows/codeql.yml`, `.github/workflows/release.yml`.
+
+## Current vs target behavior
+
+| Action | From | To | Source PR | Files |
+|--------|------|----|-----------|-------|
+| github/codeql-action/* | v3 | v4 | #39 | codeql.yml (init, analyze), ci.yml (upload-sarif) |
+| actions/setup-python | v4/v5 | v6 | #34 | ci.yml, release.yml |
+| actions/upload-artifact | v3/v4 | v5 | #41 | ci.yml, release.yml |
+| azure/setup-helm | v3 | v4 | #15 | release.yml |
+
+### Obsolete PR
+- #9 `codecov/codecov-action` 3→5 — `ci.yml` already pins `@v5`, so no change is needed.
+
+## Technical approach and alternatives
+
+Pin each action to the new major tag across all workflow files. Alternative (rejected): merge each
+Dependabot PR separately — more CI runs and review overhead for trivial tag bumps.
+
+## Risk / failure modes and mitigations
+
+- `codeql-action@v4` and `setup-python@v6` are major bumps; behavior is backward compatible for our
+  usage (default inputs). Mitigation: full `CI Pipeline` run validates on the PR.
+- `upload-artifact@v4+` changed artifact immutability semantics (no same-name re-upload). Our
+  workflows upload a single `build-artifacts` and SARIF once per run, so unaffected.
+
+## Test strategy and validation
+
+- YAML lint (`python -c "import yaml; ..."`).
+- Full `CI Pipeline` green on the PR (exercises setup-python, upload-artifact, codeql upload-sarif).
+- `release.yml` actions are validated by syntax + the next release run; low risk (tag bumps only).
+
+## Rollout / backout
+
+- Rollout: merge to `main`.
+- Backout: revert the workflow edits.


### PR DESCRIPTION
## Summary
Consolidates the still-relevant Dependabot GitHub Actions bumps into one change.

| Action | From | To | Source |
|--------|------|----|--------|
| github/codeql-action/* | v3 | v4 | #39 |
| actions/setup-python | v4/v5 | v6 | #34 |
| actions/upload-artifact | v3/v4 | v5 | #41 |
| azure/setup-helm | v3 | v4 | #15 |

`codecov/codecov-action` (#9) is already at `@v5` → obsolete, no change.

## Supersedes / closes
Supersedes #39, #34, #41, #15. Obsoletes #9 (already v5).

## Spec
docs/superpowers/specs/2026-05-29-pr-47-github-actions-deps-design.md

## Verification
- YAML validated for ci.yml/codeql.yml/release.yml.
- Full `CI Pipeline` run on this PR exercises setup-python, upload-artifact and codeql upload-sarif.

## Checklist
- [x] Scope: GitHub Actions tag bumps only.
- [x] Correctness: workflows parse; CI green.
- [x] Docs: design spec added.
- [x] Tracking: plan updated.
