### PR TITLE
chore(docker): bump base images (golang 1.25-alpine, python 3.14-slim)

### DIFF
--- a/deploy/docker/Dockerfile.api
+++ b/deploy/docker/Dockerfile.api
@@ -1,5 +1,5 @@
 # Multi-stage build for Go API server
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 # Install git and ca-certificates
 RUN apk add --no-cache git ca-certificates tzdata

--- a/deploy/docker/Dockerfile.cli
+++ b/deploy/docker/Dockerfile.cli
@@ -1,5 +1,5 @@
 # Python CLI container
-FROM python:3.13-slim
+FROM python:3.14-slim
 
 # Set environment variables
 ENV PYTHONUNBUFFERED=1 \

--- a/deploy/docker/Dockerfile.controller
+++ b/deploy/docker/Dockerfile.controller
@@ -1,5 +1,5 @@
 # Multi-stage build for Go controller
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 # Install dependencies
 RUN apk add --no-cache git ca-certificates tzdata

--- a/deploy/docker/Dockerfile.monitor
+++ b/deploy/docker/Dockerfile.monitor
@@ -1,5 +1,5 @@
 # Multi-stage build for Go monitor service
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 # Install git and ca-certificates (needed for go mod download)
 RUN apk add --no-cache git ca-certificates tzdata

--- a/docs/superpowers/specs/2026-05-29-pr-48-docker-image-deps-design.md
+++ b/docs/superpowers/specs/2026-05-29-pr-48-docker-image-deps-design.md
@@ -1,0 +1,45 @@
+# Design (PR #48): Docker base image dependency bumps
+
+- Date: 2026-05-29
+- Status: Implemented
+- Supersedes Dependabot PRs: #31 (golang base), #40 (python base).
+
+## Problem statement and scope
+
+Dependabot proposes newer base images for the container builds. Consolidate into a single change.
+
+Scope: `deploy/docker/Dockerfile.api`, `Dockerfile.controller`, `Dockerfile.monitor`,
+`Dockerfile.cli`.
+
+## Current vs target behavior
+
+| Image | From | To | Source PR | Files |
+|-------|------|----|-----------|-------|
+| golang (builder) | 1.24-alpine | 1.25-alpine | #31 | Dockerfile.api, .controller, .monitor |
+| python (runtime) | 3.13-slim | 3.14-slim | #40 | Dockerfile.cli |
+
+`go.mod` requires `go 1.24.0` (set in #46); `golang:1.25-alpine` satisfies this.
+
+## Technical approach and alternatives
+
+Update the `FROM` lines. Alternative (rejected): merge each Dependabot PR separately.
+
+## Risk / failure modes and mitigations
+
+- **python:3.14-slim** could break the CLI image if a dependency lacks 3.14 wheels. Mitigation:
+  the test suite already runs on Python 3.14 locally (pytest green), indicating the package and its
+  dependencies install/run on 3.14. The `Container Build Test` CI job is the gate; if it fails,
+  hold #40 (revert the python bump) and record in backlog rather than force-merge.
+- golang 1.25-alpine builder is a minor bump; Go is backward compatible. Validated by the Go
+  builder stages in `Container Build Test`.
+
+## Test strategy and validation
+
+- `Container Build Test` CI job builds all three container images (monitor, api, cli).
+- No local Docker available in the working environment; CI is the authoritative gate.
+
+## Rollout / backout
+
+- Rollout: merge to `main`.
+- Backout: revert the `FROM` line(s). The python and golang bumps are independent and can be
+  reverted separately if only one base image regresses.


### PR DESCRIPTION
## Summary
Consolidates the Dependabot container base-image bumps into one change.

| Image | From | To | Source |
|-------|------|----|--------|
| golang (builder) | 1.24-alpine | 1.25-alpine | #31 |
| python (runtime) | 3.13-slim | 3.14-slim | #40 |

## Supersedes / closes
Supersedes #31 and #40.

## Spec
docs/superpowers/specs/2026-05-29-pr-48-docker-image-deps-design.md

## Verification
- Gated on the `Container Build Test` CI job (builds monitor/api/cli images). No local Docker in the working env.
- The Python test suite already runs green on Python 3.14 locally, indicating dependency compatibility.

## Risk / backout
If `python:3.14-slim` breaks the CLI image build, the python bump (#40) will be reverted and moved to backlog; the golang bump is independent.

## Checklist
- [x] Scope: container base-image bumps only.
- [x] Correctness: gated on Container Build Test.
- [x] Docs: design spec added.
- [x] Tracking: plan updated.
