### PR TITLE
fix(python): PR-2 monitor contract alignment and UTC datetimes

### DIFF
--- a/docs/superpowers/plans/2026-05-28-repo-health-remediation.md
+++ b/docs/superpowers/plans/2026-05-28-repo-health-remediation.md
@@ -98,8 +98,8 @@ Suggested worktree layout:
 - **Current phase:** Phase 1 - Security and correctness baseline (implementation starts at PR 1)
 - **Primary owner:** TBD
 - **Last updated:** 2026-05-29
-- **Last merged:** Foundation governance PR [#43](https://github.com/tomazb/kubernetes-truenas-democratic-tool/pull/43) (2026-05-29)
-- **Next up:** PR 1 - Security baseline hardening
+- **Last merged:** PR 1 security baseline [#44](https://github.com/tomazb/kubernetes-truenas-democratic-tool/pull/44) (2026-05-29)
+- **Next up:** PR 2 - Python correctness and contract alignment
 
 ## Milestones
 
@@ -159,7 +159,7 @@ Suggested worktree layout:
 
 ### PR 1: Security Baseline Hardening
 
-- **Status:** In Progress
+- **Status:** Done
 - **Risk:** High
 - **Focus:** Secure TLS defaults for TrueNAS communication.
 - **Branch/worktree:**
@@ -184,7 +184,7 @@ Suggested worktree layout:
 
 ### PR 2: Python Correctness and Contract Alignment
 
-- **Status:** Planned
+- **Status:** In Progress
 - **Risk:** High
 - **Focus:** Remove runtime mismatches and datetime bugs in monitor path.
 - **Branch/worktree:**
@@ -198,15 +198,15 @@ Suggested worktree layout:
   - `python/tests/unit/test_monitor*.py`
   - `python/tests/unit/test_k8s_client*.py`
 - **Implementation steps:**
-  - [ ] Fix monitor-to-client method contract mismatches.
-  - [ ] Resolve config shape mismatch (`kubernetes` vs `openshift` semantics).
-  - [ ] Standardize datetime comparisons to timezone-aware UTC.
-  - [ ] Add tests for mixed timezone inputs and boundary behavior.
-  - [ ] Validate monitor initialization with real public APIs.
+  - [x] Fix monitor-to-client method contract mismatches.
+  - [x] Resolve config shape mismatch (`kubernetes` vs `openshift` semantics).
+  - [x] Standardize datetime comparisons to timezone-aware UTC.
+  - [x] Add tests for mixed timezone inputs and boundary behavior.
+  - [x] Validate monitor initialization with real public APIs.
 - **Acceptance criteria:**
-  - [ ] No naive/aware datetime comparison failures.
-  - [ ] Monitor initialization and checks use valid client methods.
-  - [ ] Unit tests cover contract and timezone edge cases.
+  - [x] No naive/aware datetime comparison failures.
+  - [x] Monitor initialization and checks use valid client methods.
+  - [x] Unit tests cover contract and timezone edge cases.
 - **PR URL:** TBD
 
 ### PR 3: Python Import and Packaging Hygiene

--- a/docs/superpowers/plans/2026-05-28-repo-health-remediation.md
+++ b/docs/superpowers/plans/2026-05-28-repo-health-remediation.md
@@ -207,7 +207,7 @@ Suggested worktree layout:
   - [x] No naive/aware datetime comparison failures.
   - [x] Monitor initialization and checks use valid client methods.
   - [x] Unit tests cover contract and timezone edge cases.
-- **PR URL:** TBD
+- **PR URL:** https://github.com/tomazb/kubernetes-truenas-democratic-tool/pull/52
 
 ### PR 3: Python Import and Packaging Hygiene
 

--- a/docs/superpowers/specs/2026-05-28-pr-2-python-correctness-design.md
+++ b/docs/superpowers/specs/2026-05-28-pr-2-python-correctness-design.md
@@ -1,0 +1,91 @@
+# PR 2: Python Correctness and Contract Alignment — Design Spec
+
+**Date:** 2026-05-28  
+**Plan item:** [Remediation plan PR 2](../plans/2026-05-28-repo-health-remediation.md)  
+**Milestone:** M1 — Baseline Safety
+
+## Problem statement and scope
+
+The Python `Monitor` class was written against a stale API: dict-based Kubernetes objects, `list_*` client methods, and a `config.kubernetes` section. The implemented stack uses typed dataclass clients (`K8sClient`, `TrueNASClient`), `get_*` methods, and an `openshift` config section. At runtime, monitor initialization and scans fail with `AttributeError` unless clients are fully mocked.
+
+Additionally, the K8s client mixes naive and timezone-aware datetimes in orphan detection and watch handlers, which can raise `TypeError` when comparing timestamps from the Kubernetes API.
+
+**In scope:**
+
+- Config normalization (`openshift` / `kubernetes` alias) and factory methods (`k8s_config()`, `truenas_config()`)
+- Monitor wiring to typed clients and real `get_*` APIs
+- Shared UTC time helpers and datetime fixes in K8s client
+- Thin `test_connection()` and `list_namespaces()` on `K8sClient`
+- Unit test updates to catch contract drift
+
+**Out of scope:**
+
+- Package `__init__.py` import side effects (PR-3)
+- Deploy manifest renames or README overhaul (PR-8)
+- Go API/detector placeholders (PR-4/5)
+- Full cross-system orphan correlation logic (future product depth)
+
+## Current behavior vs target behavior
+
+| Aspect | Current | Target |
+|--------|---------|--------|
+| Monitor init | `K8sClient(config.kubernetes)` dict | `K8sClient(config.k8s_config())` |
+| TrueNAS init | `TrueNASClient(config.truenas)` dict | `TrueNASClient(config.truenas_config())` |
+| K8s resource fetch | `list_persistent_volumes()` etc. | `get_persistent_volumes()` etc. |
+| Config section | `kubernetes` (missing on `Config`) | `openshift` canonical; `kubernetes` alias at load |
+| Datetime comparisons | Mixed naive/aware | Always UTC-aware via helpers |
+| CSI health | `list_pods()` + nested status dict | `check_csi_driver_health()` |
+| Unit tests | Mock non-existent APIs | Test real method names and dataclass shapes |
+
+## Technical approach
+
+1. Add `normalize_cluster_config()` in `load_config()` to merge `kubernetes` → `openshift`.
+2. Add `Config.k8s_config()` and `Config.truenas_config()` factory methods.
+3. Add `time_utils.py` with `utc_now()`, `ensure_utc()`, `parse_rfc3339()`.
+4. Add `test_connection()` and `list_namespaces()` to `K8sClient`; fix datetime usage.
+5. Refactor `monitor.py` to use dataclass fields from client return types.
+6. Update unit tests for config factories, monitor contract, and timezone edge cases.
+
+**Alternatives considered:**
+
+| Alternative | Decision |
+|-------------|----------|
+| Add `list_*` aliases on clients only | Rejected — does not fix dict vs dataclass mismatch |
+| Refactor monitor to dataclass fields | Accepted — aligns with client design |
+| Rename deploy ConfigMap to `openshift` | Deferred to PR-8; load-time alias covers runtime |
+
+## Risk, failure modes, and mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Monitor output shape changes | Keep top-level result dict keys stable |
+| URL parsing edge cases for TrueNAS | Table-driven tests for host/port variants |
+| Backward compat for `kubernetes` key | Load-time normalization + deprecated property alias |
+| Tests masked by full client patching | Partial mocks with real method names |
+
+## Test strategy
+
+| Test | Purpose |
+|------|---------|
+| `test_k8s_config_from_openshift` | Factory maps openshift → K8sConfig |
+| `test_kubernetes_alias_normalized` | `kubernetes` section accepted at load |
+| `test_truenas_config_url_parsing` | URL → host/port, insecure → verify_ssl |
+| `test_parse_rfc3339_*` | Aware UTC parsing |
+| `test_find_orphaned_pvcs_timezone` | Naive/aware creation_time handling |
+| `test_monitor_initialization` | Factory wiring to typed clients |
+| `test_find_orphaned_resources_success` | Real method names + dataclass fixtures |
+
+**Validation commands:**
+
+```bash
+cd python && pytest tests/unit/test_config.py tests/unit/test_monitor.py tests/unit/test_k8s_client.py tests/unit/test_time_utils.py -v
+make python-test
+make python-lint
+cd python && bandit -r .
+```
+
+## Rollout and backout
+
+**Rollout:** Deploy updated Python monitor/CLI; existing configs with `openshift` or `kubernetes` sections continue to work via normalization.
+
+**Backout:** Revert to previous release; no schema migration required.

--- a/python/tests/unit/test_config.py
+++ b/python/tests/unit/test_config.py
@@ -251,7 +251,7 @@ class TestConfigClass:
 
     def test_normalize_cluster_config_rejects_non_mapping(self):
         """Non-mapping kubernetes section raises ConfigurationError."""
-        with pytest.raises(ConfigurationError, match="kubernetes.*mapping"):
+        with pytest.raises(ConfigurationError, match=r"kubernetes.*mapping"):
             normalize_cluster_config({"kubernetes": "invalid"})
 
     def test_parse_timeout_seconds(self):

--- a/python/tests/unit/test_config.py
+++ b/python/tests/unit/test_config.py
@@ -4,11 +4,15 @@ import pytest
 from unittest.mock import patch, mock_open
 
 from truenas_storage_monitor.config import (
+    Config,
     load_config,
     get_default_config,
     expand_env_vars,
     validate_config,
     merge_configs,
+    normalize_cluster_config,
+    parse_truenas_url,
+    parse_timeout_seconds,
 )
 from truenas_storage_monitor.exceptions import ConfigurationError
 
@@ -130,3 +134,89 @@ class TestConfigModule:
         """Test error when config file not found."""
         with pytest.raises(ConfigurationError, match="Configuration file not found"):
             load_config("/nonexistent/config.yaml")
+
+
+class TestConfigClass:
+    """Test cases for the Config class factory methods."""
+
+    def test_k8s_config_from_openshift(self):
+        """openshift section maps to K8sConfig."""
+        config = Config.__new__(Config)
+        config.data = {
+            "openshift": {
+                "kubeconfig": "/tmp/kubeconfig",
+                "namespace": "democratic-csi",
+                "csi_driver": "org.democratic-csi.iscsi",
+                "in_cluster": True,
+            }
+        }
+
+        k8s_config = config.k8s_config()
+
+        assert k8s_config.kubeconfig == "/tmp/kubeconfig"
+        assert k8s_config.namespace == "democratic-csi"
+        assert k8s_config.csi_driver == "org.democratic-csi.iscsi"
+        assert k8s_config.in_cluster is True
+
+    def test_kubernetes_property_aliases_openshift(self):
+        """kubernetes property returns openshift section."""
+        config = Config.__new__(Config)
+        config.data = {"openshift": {"namespace": "democratic-csi"}}
+
+        assert config.kubernetes == config.openshift
+
+    def test_truenas_config_url_parsing(self):
+        """truenas URL maps to TrueNASConfig host/port."""
+        config = Config.__new__(Config)
+        config.data = {
+            "truenas": {
+                "url": "https://truenas.example.com:8443",
+                "api_key": "secret",
+                "insecure": True,
+                "timeout": "45s",
+            }
+        }
+
+        truenas_config = config.truenas_config()
+
+        assert truenas_config.host == "truenas.example.com"
+        assert truenas_config.port == 8443
+        assert truenas_config.verify_ssl is False
+        assert truenas_config.timeout == 45
+
+    def test_normalize_cluster_config_kubernetes_only(self):
+        """kubernetes section is normalized to openshift."""
+        config = normalize_cluster_config(
+            {
+                "kubernetes": {"namespace": "democratic-csi", "in_cluster": True},
+                "monitoring": {},
+            }
+        )
+
+        assert "kubernetes" not in config
+        assert config["openshift"]["namespace"] == "democratic-csi"
+        assert config["openshift"]["in_cluster"] is True
+
+    def test_normalize_cluster_config_merge_precedence(self):
+        """openshift values override kubernetes during merge."""
+        config = normalize_cluster_config(
+            {
+                "kubernetes": {"namespace": "legacy", "in_cluster": True},
+                "openshift": {"namespace": "democratic-csi"},
+                "monitoring": {},
+            }
+        )
+
+        assert config["openshift"]["namespace"] == "democratic-csi"
+        assert config["openshift"]["in_cluster"] is True
+
+    def test_parse_truenas_url_host_only(self):
+        """Host-only URLs default to HTTPS port 443."""
+        host, port = parse_truenas_url("truenas.example.com")
+        assert host == "truenas.example.com"
+        assert port == 443
+
+    def test_parse_timeout_seconds(self):
+        """Timeout strings with s suffix parse to integers."""
+        assert parse_timeout_seconds(30) == 30
+        assert parse_timeout_seconds("30s") == 30

--- a/python/tests/unit/test_config.py
+++ b/python/tests/unit/test_config.py
@@ -181,8 +181,10 @@ class TestConfigClass:
 
         assert truenas_config.host == "truenas.example.com"
         assert truenas_config.port == 8443
+        assert truenas_config.use_https is True
         assert truenas_config.verify_ssl is False
         assert truenas_config.timeout == 45
+        assert truenas_config.base_url == "https://truenas.example.com:8443/api/v2.0"
 
     def test_normalize_cluster_config_kubernetes_only(self):
         """kubernetes section is normalized to openshift."""
@@ -212,9 +214,45 @@ class TestConfigClass:
 
     def test_parse_truenas_url_host_only(self):
         """Host-only URLs default to HTTPS port 443."""
-        host, port = parse_truenas_url("truenas.example.com")
+        host, port, use_https = parse_truenas_url("truenas.example.com")
         assert host == "truenas.example.com"
         assert port == 443
+        assert use_https is True
+
+    def test_parse_truenas_url_https_custom_port(self):
+        """HTTPS URLs on non-default ports preserve TLS scheme."""
+        host, port, use_https = parse_truenas_url("https://truenas.example.com:8443")
+        assert host == "truenas.example.com"
+        assert port == 8443
+        assert use_https is True
+
+    def test_parse_timeout_seconds_rejects_bool(self):
+        """Boolean timeout values raise ConfigurationError."""
+        with pytest.raises(ConfigurationError, match="Invalid timeout value"):
+            parse_timeout_seconds(True)
+
+    def test_parse_timeout_seconds_rejects_invalid_string(self):
+        """Malformed timeout strings raise ConfigurationError."""
+        with pytest.raises(ConfigurationError, match="Invalid timeout value"):
+            parse_timeout_seconds("30as")
+
+    def test_parse_timeout_seconds_rejects_non_positive(self):
+        """Zero or negative timeouts raise ConfigurationError."""
+        with pytest.raises(ConfigurationError, match="Timeout must be > 0"):
+            parse_timeout_seconds(0)
+
+    def test_truenas_config_missing_url(self):
+        """Missing TrueNAS URL raises ConfigurationError."""
+        config = Config.__new__(Config)
+        config.data = {"truenas": {"api_key": "secret"}}
+
+        with pytest.raises(ConfigurationError, match="TrueNAS URL is required"):
+            config.truenas_config()
+
+    def test_normalize_cluster_config_rejects_non_mapping(self):
+        """Non-mapping kubernetes section raises ConfigurationError."""
+        with pytest.raises(ConfigurationError, match="kubernetes.*mapping"):
+            normalize_cluster_config({"kubernetes": "invalid"})
 
     def test_parse_timeout_seconds(self):
         """Timeout strings with s suffix parse to integers."""

--- a/python/tests/unit/test_k8s_client.py
+++ b/python/tests/unit/test_k8s_client.py
@@ -2,7 +2,7 @@
 
 import pytest
 from unittest.mock import Mock, patch
-from datetime import datetime
+from datetime import datetime, timezone
 from kubernetes.client.rest import ApiException
 
 from truenas_storage_monitor.k8s_client import (
@@ -278,7 +278,7 @@ class TestK8sClient:
         pvc1 = Mock()
         pvc1.metadata.name = "pvc-orphaned"
         pvc1.metadata.namespace = "test-namespace"
-        pvc1.metadata.creation_timestamp = datetime(2024, 1, 1)
+        pvc1.metadata.creation_timestamp = datetime(2024, 1, 1, tzinfo=timezone.utc)
         pvc1.spec.storage_class_name = "democratic-csi-nfs"
         pvc1.status.phase = "Pending"
 
@@ -291,6 +291,60 @@ class TestK8sClient:
         assert len(orphans) == 1
         assert orphans[0].resource_type == ResourceType.PERSISTENT_VOLUME_CLAIM
         assert orphans[0].name == "pvc-orphaned"
+
+    def test_find_orphaned_pvcs_empty_list(self, mock_client):
+        """Empty PVC list does not raise during orphan detection."""
+        mock_client.core_v1.list_namespaced_persistent_volume_claim.return_value = Mock(items=[])
+
+        orphans = mock_client.find_orphaned_pvcs(pending_threshold_minutes=60)
+
+        assert orphans == []
+
+    def test_find_orphaned_pvcs_naive_creation_time(self, mock_client):
+        """Naive PVC creation timestamps compare safely against UTC threshold."""
+        pvc1 = Mock()
+        pvc1.metadata.name = "pvc-naive"
+        pvc1.metadata.namespace = "test-namespace"
+        pvc1.metadata.creation_timestamp = datetime(2024, 1, 1)
+        pvc1.spec.storage_class_name = "democratic-csi-nfs"
+        pvc1.status.phase = "Pending"
+
+        mock_client.core_v1.list_namespaced_persistent_volume_claim.return_value = Mock(
+            items=[pvc1]
+        )
+
+        orphans = mock_client.find_orphaned_pvcs(pending_threshold_minutes=60)
+
+        assert len(orphans) == 1
+        assert orphans[0].name == "pvc-naive"
+
+    def test_test_connection_success(self, mock_client):
+        """test_connection succeeds when API responds."""
+        mock_client.core_v1.list_namespace.return_value = Mock(items=[])
+
+        assert mock_client.test_connection() is True
+        mock_client.core_v1.list_namespace.assert_called_once_with(limit=1)
+
+    def test_test_connection_failure(self, mock_client):
+        """test_connection propagates API failures."""
+        mock_client.core_v1.list_namespace.side_effect = ApiException(
+            status=401, reason="Unauthorized"
+        )
+
+        with pytest.raises(ApiException):
+            mock_client.test_connection()
+
+    def test_list_namespaces(self, mock_client):
+        """list_namespaces returns namespace names."""
+        ns1 = Mock()
+        ns1.metadata.name = "default"
+        ns2 = Mock()
+        ns2.metadata.name = "democratic-csi"
+        mock_client.core_v1.list_namespace.return_value = Mock(items=[ns1, ns2])
+
+        names = mock_client.list_namespaces()
+
+        assert names == ["default", "democratic-csi"]
 
     def test_error_handling_api_exception(self, mock_client):
         """Test error handling for Kubernetes API exceptions."""

--- a/python/tests/unit/test_monitor.py
+++ b/python/tests/unit/test_monitor.py
@@ -7,6 +7,12 @@ from datetime import datetime, timedelta, timezone
 from truenas_storage_monitor.monitor import Monitor
 from truenas_storage_monitor.config import Config
 from truenas_storage_monitor.exceptions import TrueNASMonitorError
+from truenas_storage_monitor.k8s_client import (
+    K8sConfig,
+    PersistentVolumeClaimInfo,
+    PersistentVolumeInfo,
+)
+from truenas_storage_monitor.truenas_client import TrueNASConfig, VolumeInfo
 
 
 class TestMonitor:
@@ -14,107 +20,117 @@ class TestMonitor:
 
     @pytest.fixture
     def mock_config(self):
-        """Create a mock configuration."""
+        """Create a mock configuration with factory methods."""
         config = Mock(spec=Config)
-        config.kubernetes = {"namespace": "democratic-csi"}
-        config.truenas = {"url": "https://truenas.test"}
+        config.openshift = {"namespace": "democratic-csi"}
+        config.k8s_config.return_value = K8sConfig(namespace="democratic-csi")
+        config.truenas_config.return_value = TrueNASConfig(
+            host="truenas.test",
+            api_key="test-key",
+        )
         return config
 
     @pytest.fixture
     def monitor(self, mock_config):
         """Create a Monitor instance with mocked dependencies."""
         with (
-            patch("truenas_storage_monitor.monitor.K8sClient"),
-            patch("truenas_storage_monitor.monitor.TrueNASClient"),
+            patch("truenas_storage_monitor.monitor.K8sClient") as mock_k8s_cls,
+            patch("truenas_storage_monitor.monitor.TrueNASClient") as mock_truenas_cls,
         ):
-            return Monitor(mock_config)
+            mock_k8s_cls.return_value = Mock()
+            mock_truenas_cls.return_value = Mock()
+            monitor = Monitor(mock_config)
+            return monitor
 
     def test_monitor_initialization(self, mock_config):
-        """Test that Monitor initializes correctly."""
+        """Test that Monitor initializes with typed client configs."""
         with (
             patch("truenas_storage_monitor.monitor.K8sClient") as mock_k8s,
             patch("truenas_storage_monitor.monitor.TrueNASClient") as mock_truenas,
         ):
-
             monitor = Monitor(mock_config)
 
             assert monitor.config == mock_config
-            mock_k8s.assert_called_once_with(mock_config.kubernetes)
-            mock_truenas.assert_called_once_with(mock_config.truenas)
+            mock_config.k8s_config.assert_called_once()
+            mock_config.truenas_config.assert_called_once()
+            mock_k8s.assert_called_once_with(mock_config.k8s_config.return_value)
+            mock_truenas.assert_called_once_with(mock_config.truenas_config.return_value)
 
     def test_find_orphaned_resources_success(self, monitor):
         """Test successful orphaned resource detection."""
-        # Mock data
+        old_created = utc_now() - timedelta(hours=25)
+
         mock_pvs = [
-            {
-                "metadata": {
-                    "name": "pv-test",
-                    "creationTimestamp": (datetime.now(timezone.utc) - timedelta(hours=25))
-                    .isoformat()
-                    .replace("+00:00", "Z"),
-                },
-                "spec": {
-                    "csi": {"driver": "democratic-csi"},
-                    "capacity": {"storage": "10Gi"},
-                    "storageClassName": "truenas-iscsi",
-                },
-            }
+            PersistentVolumeInfo(
+                name="pv-test",
+                volume_handle="vol-test",
+                driver="org.democratic-csi.nfs",
+                capacity="10Gi",
+                access_modes=["ReadWriteOnce"],
+                phase="Bound",
+                creation_time=old_created,
+            )
         ]
 
         mock_pvcs = [
-            {
-                "metadata": {
-                    "name": "pvc-test",
-                    "namespace": "default",
-                    "creationTimestamp": (datetime.now(timezone.utc) - timedelta(hours=25))
-                    .isoformat()
-                    .replace("+00:00", "Z"),
-                },
-                "status": {"phase": "Pending"},
-                "spec": {
-                    "resources": {"requests": {"storage": "5Gi"}},
-                    "storageClassName": "truenas-iscsi",
-                },
-            }
+            PersistentVolumeClaimInfo(
+                name="pvc-test",
+                namespace="default",
+                storage_class="truenas-iscsi",
+                volume_name=None,
+                capacity="5Gi",
+                phase="Pending",
+                creation_time=old_created,
+            )
         ]
 
-        mock_snapshots = []
-        mock_truenas_volumes = []
-        mock_truenas_snapshots = []
+        monitor.k8s_client.get_persistent_volumes.return_value = mock_pvs
+        monitor.k8s_client.get_persistent_volume_claims.return_value = mock_pvcs
+        monitor.k8s_client.get_volume_snapshots.return_value = []
+        monitor.truenas_client.get_volumes.return_value = []
+        monitor.truenas_client.get_snapshots.return_value = []
 
-        # Setup mocks
-        monitor.k8s_client.list_persistent_volumes.return_value = mock_pvs
-        monitor.k8s_client.list_persistent_volume_claims.return_value = mock_pvcs
-        monitor.k8s_client.list_volume_snapshots.return_value = mock_snapshots
-        monitor.truenas_client.list_volumes.return_value = mock_truenas_volumes
-        monitor.truenas_client.list_snapshots.return_value = mock_truenas_snapshots
-
-        # Execute
         result = monitor.find_orphaned_resources()
 
-        # Verify
         assert "timestamp" in result
-        assert "orphaned_pvs" in result
-        assert "orphaned_pvcs" in result
-        assert "orphaned_snapshots" in result
         assert result["total_pvs"] == 1
         assert result["total_pvcs"] == 1
-        assert result["total_snapshots"] == 0
-
-        # Should find orphaned PV (no corresponding TrueNAS volume)
         assert len(result["orphaned_pvs"]) == 1
         assert result["orphaned_pvs"][0]["name"] == "pv-test"
-
-        # Should find orphaned PVC (pending for > 24h)
         assert len(result["orphaned_pvcs"]) == 1
         assert result["orphaned_pvcs"][0]["name"] == "pvc-test"
 
+    def test_find_orphaned_resources_naive_creation_time(self, monitor):
+        """Naive creation timestamps do not raise TypeError."""
+        naive_created = datetime(2020, 1, 1, 0, 0, 0)
+
+        mock_pvs = [
+            PersistentVolumeInfo(
+                name="pv-naive",
+                volume_handle="vol-naive",
+                driver="org.democratic-csi.nfs",
+                capacity="10Gi",
+                access_modes=["ReadWriteOnce"],
+                phase="Bound",
+                creation_time=naive_created,
+            )
+        ]
+
+        monitor.k8s_client.get_persistent_volumes.return_value = mock_pvs
+        monitor.k8s_client.get_persistent_volume_claims.return_value = []
+        monitor.k8s_client.get_volume_snapshots.return_value = []
+        monitor.truenas_client.get_volumes.return_value = []
+        monitor.truenas_client.get_snapshots.return_value = []
+
+        result = monitor.find_orphaned_resources()
+
+        assert len(result["orphaned_pvs"]) == 1
+        assert result["orphaned_pvs"][0]["name"] == "pv-naive"
+
     def test_find_orphaned_resources_error_handling(self, monitor):
         """Test error handling in orphaned resource detection."""
-        # Setup mock to raise exception
-        monitor.k8s_client.list_persistent_volumes.side_effect = Exception("K8s API error")
+        monitor.k8s_client.get_persistent_volumes.side_effect = Exception("K8s API error")
 
-        # Execute and verify exception
         with pytest.raises(TrueNASMonitorError) as exc_info:
             monitor.find_orphaned_resources()
 
@@ -122,25 +138,35 @@ class TestMonitor:
 
     def test_is_democratic_csi_pv(self, monitor):
         """Test democratic-csi PV detection."""
-        # Test positive case
-        pv_democratic = {"spec": {"csi": {"driver": "org.democratic-csi.iscsi"}}}
-        assert monitor._is_democratic_csi_pv(pv_democratic) is True
-
-        # Test TrueNAS driver
-        pv_truenas = {"spec": {"csi": {"driver": "truenas.csi.driver"}}}
-        assert monitor._is_democratic_csi_pv(pv_truenas) is True
-
-        # Test negative case
-        pv_other = {"spec": {"csi": {"driver": "other.csi.driver"}}}
-        assert monitor._is_democratic_csi_pv(pv_other) is False
-
-        # Test missing CSI info
-        pv_no_csi = {"spec": {}}
-        assert monitor._is_democratic_csi_pv(pv_no_csi) is False
+        assert (
+            monitor._is_democratic_csi_pv(
+                PersistentVolumeInfo(
+                    name="pv1",
+                    volume_handle="v1",
+                    driver="org.democratic-csi.iscsi",
+                    capacity="1Gi",
+                    access_modes=[],
+                    phase="Bound",
+                )
+            )
+            is True
+        )
+        assert (
+            monitor._is_democratic_csi_pv(
+                PersistentVolumeInfo(
+                    name="pv2",
+                    volume_handle="v2",
+                    driver="other.csi.driver",
+                    capacity="1Gi",
+                    access_modes=[],
+                    phase="Bound",
+                )
+            )
+            is False
+        )
 
     def test_parse_storage_size(self, monitor):
         """Test storage size parsing."""
-        # Test various formats
         assert monitor._parse_storage_size("1Gi") == 1024**3
         assert monitor._parse_storage_size("5G") == 5 * 1024**3
         assert monitor._parse_storage_size("100Mi") == 100 * 1024**2
@@ -151,65 +177,83 @@ class TestMonitor:
 
     def test_analyze_storage_usage(self, monitor):
         """Test storage usage analysis."""
-        # Mock data
         mock_pvcs = [
-            {"spec": {"resources": {"requests": {"storage": "10Gi"}}}},
-            {"spec": {"resources": {"requests": {"storage": "5Gi"}}}},
+            PersistentVolumeClaimInfo(
+                name="pvc1",
+                namespace="default",
+                storage_class="sc1",
+                volume_name="pv1",
+                capacity="10Gi",
+                phase="Bound",
+            ),
+            PersistentVolumeClaimInfo(
+                name="pvc2",
+                namespace="default",
+                storage_class="sc1",
+                volume_name="pv2",
+                capacity="5Gi",
+                phase="Bound",
+            ),
         ]
 
-        mock_pvs = [{"metadata": {"name": "pv1"}}, {"metadata": {"name": "pv2"}}]
+        mock_pvs = [
+            PersistentVolumeInfo(
+                name="pv1",
+                volume_handle="v1",
+                driver="org.democratic-csi.nfs",
+                capacity="10Gi",
+                access_modes=[],
+                phase="Bound",
+            )
+        ]
         mock_truenas_volumes = [
-            {"used_bytes": 5 * 1024**3},  # 5GB used
-            {"used_bytes": 3 * 1024**3},  # 3GB used
+            VolumeInfo(name="vol1", path="/mnt/1", size=5 * 1024**3, type="FILE", enabled=True),
+            VolumeInfo(name="vol2", path="/mnt/2", size=3 * 1024**3, type="FILE", enabled=True),
         ]
 
-        # Setup mocks
-        monitor.k8s_client.list_persistent_volume_claims.return_value = mock_pvcs
-        monitor.k8s_client.list_persistent_volumes.return_value = mock_pvs
-        monitor.truenas_client.list_volumes.return_value = mock_truenas_volumes
+        monitor.k8s_client.get_persistent_volume_claims.return_value = mock_pvcs
+        monitor.k8s_client.get_persistent_volumes.return_value = mock_pvs
+        monitor.truenas_client.get_volumes.return_value = mock_truenas_volumes
 
-        # Execute
         result = monitor.analyze_storage_usage()
 
-        # Verify
-        assert result["total_allocated_gb"] == 15.0  # 10Gi + 5Gi
-        assert result["total_used_gb"] == 8.0  # 5GB + 3GB
+        assert result["total_allocated_gb"] == 15.0
+        assert result["total_used_gb"] == 8.0
         assert result["total_pvcs"] == 2
-        assert result["total_pvs"] == 2
+        assert result["total_pvs"] == 1
         assert "thin_provisioning_efficiency" in result
         assert "recommendations" in result
 
     def test_check_health(self, monitor):
         """Test health check functionality."""
-        # Setup mocks for healthy state
-        monitor.k8s_client.test_connection.return_value = None
-        monitor.truenas_client.test_connection.return_value = None
-        monitor.k8s_client.list_pods.return_value = [
-            {"status": {"phase": "Running"}},
-            {"status": {"phase": "Running"}},
-        ]
+        monitor.k8s_client.test_connection.return_value = True
+        monitor.truenas_client.test_connection.return_value = True
+        monitor.k8s_client.check_csi_driver_health.return_value = {
+            "healthy": True,
+            "reason": "All pods running and ready",
+            "total_pods": 2,
+            "running_pods": 2,
+            "ready_pods": 2,
+        }
 
-        # Execute
         result = monitor.check_health()
 
-        # Verify
         assert result["healthy"] is True
-        assert "components" in result
         assert result["components"]["kubernetes"]["healthy"] is True
         assert result["components"]["truenas"]["healthy"] is True
         assert result["components"]["csi_driver"]["healthy"] is True
 
     def test_check_health_with_failures(self, monitor):
         """Test health check with component failures."""
-        # Setup mocks for unhealthy state
         monitor.k8s_client.test_connection.side_effect = Exception("Connection failed")
-        monitor.truenas_client.test_connection.return_value = None
-        monitor.k8s_client.list_pods.return_value = []
+        monitor.truenas_client.test_connection.return_value = True
+        monitor.k8s_client.check_csi_driver_health.return_value = {
+            "healthy": False,
+            "reason": "No CSI driver pods found",
+        }
 
-        # Execute
         result = monitor.check_health()
 
-        # Verify
         assert result["healthy"] is False
         assert result["components"]["kubernetes"]["healthy"] is False
         assert result["components"]["truenas"]["healthy"] is True
@@ -217,28 +261,38 @@ class TestMonitor:
 
     def test_generate_recommendations(self, monitor):
         """Test recommendation generation."""
-        # Mock data with large PVC
         mock_pvcs = [
-            {
-                "metadata": {"name": "large-pvc"},
-                "spec": {"resources": {"requests": {"storage": "200Gi"}}},
-            },
-            {
-                "metadata": {"name": "normal-pvc"},
-                "spec": {"resources": {"requests": {"storage": "10Gi"}}},
-            },
+            PersistentVolumeClaimInfo(
+                name="large-pvc",
+                namespace="default",
+                storage_class="sc1",
+                volume_name="pv1",
+                capacity="200Gi",
+                phase="Bound",
+            ),
+            PersistentVolumeClaimInfo(
+                name="normal-pvc",
+                namespace="default",
+                storage_class="sc1",
+                volume_name="pv2",
+                capacity="10Gi",
+                phase="Bound",
+            ),
         ]
 
         mock_truenas_volumes = [
-            {"name": "vol1"},
-            {"name": "vol2"},
-            {"name": "vol3"},  # More volumes than PVCs
+            VolumeInfo(name="vol1", path="/1", size=1, type="FILE", enabled=True),
+            VolumeInfo(name="vol2", path="/2", size=1, type="FILE", enabled=True),
+            VolumeInfo(name="vol3", path="/3", size=1, type="FILE", enabled=True),
         ]
 
-        # Execute
         recommendations = monitor._generate_recommendations(mock_pvcs, mock_truenas_volumes)
 
-        # Verify
         assert len(recommendations) >= 1
         assert any("large-pvc" in rec for rec in recommendations)
         assert any("unused TrueNAS volumes" in rec for rec in recommendations)
+
+
+def utc_now():
+    """Local helper mirroring production UTC helper."""
+    return datetime.now(timezone.utc)

--- a/python/tests/unit/test_time_utils.py
+++ b/python/tests/unit/test_time_utils.py
@@ -1,0 +1,58 @@
+"""Unit tests for timezone helpers."""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from truenas_storage_monitor.time_utils import ensure_utc, parse_rfc3339, resource_age, utc_now
+
+
+class TestTimeUtils:
+    """Test cases for time utility helpers."""
+
+    def test_utc_now_is_aware(self):
+        """utc_now returns timezone-aware UTC datetimes."""
+        now = utc_now()
+        assert now.tzinfo is not None
+        assert now.tzinfo == timezone.utc
+
+    def test_ensure_utc_from_naive(self):
+        """Naive datetimes are treated as UTC."""
+        naive = datetime(2024, 1, 1, 12, 0, 0)
+        result = ensure_utc(naive)
+        assert result.tzinfo == timezone.utc
+        assert result.hour == 12
+
+    def test_ensure_utc_from_aware(self):
+        """Aware datetimes are converted to UTC."""
+        aware = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        result = ensure_utc(aware)
+        assert result.tzinfo == timezone.utc
+
+    def test_parse_rfc3339_with_z_suffix(self):
+        """RFC3339 timestamps with Z suffix parse to aware UTC."""
+        parsed = parse_rfc3339("2024-06-01T10:15:30Z")
+        assert parsed.tzinfo == timezone.utc
+        assert parsed.year == 2024
+
+    def test_parse_rfc3339_with_offset(self):
+        """RFC3339 timestamps with numeric offsets parse to UTC."""
+        parsed = parse_rfc3339("2024-06-01T10:15:30+00:00")
+        assert parsed.tzinfo == timezone.utc
+
+    def test_parse_rfc3339_naive_input(self):
+        """Naive RFC3339-like timestamps become aware UTC."""
+        parsed = parse_rfc3339("2024-06-01T10:15:30")
+        assert parsed.tzinfo == timezone.utc
+
+    def test_parse_rfc3339_empty_raises(self):
+        """Empty timestamp strings raise ValueError."""
+        with pytest.raises(ValueError):
+            parse_rfc3339("")
+
+    def test_resource_age_returns_string(self):
+        """resource_age formats a non-empty age string."""
+        created = utc_now()
+        age = resource_age(created)
+        assert age is not None
+        assert "0:00:" in age

--- a/python/tests/unit/test_truenas_client.py
+++ b/python/tests/unit/test_truenas_client.py
@@ -39,6 +39,16 @@ class TestTrueNASConfig:
         assert config.password == "secret"
         assert config.api_key is None
 
+    def test_config_https_custom_port(self):
+        """Custom HTTPS ports keep TLS in base_url."""
+        config = TrueNASConfig(
+            host="truenas.example.com",
+            port=8443,
+            use_https=True,
+            api_key="test-api-key",
+        )
+        assert config.base_url == "https://truenas.example.com:8443/api/v2.0"
+
     def test_config_validation_no_auth(self):
         """Test configuration validation with no authentication."""
         with pytest.raises(ValueError, match="Either api_key or username/password"):

--- a/python/truenas_storage_monitor/config.py
+++ b/python/truenas_storage_monitor/config.py
@@ -2,11 +2,14 @@
 
 import os
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
+from urllib.parse import urlparse
 
 import yaml
 
 from .exceptions import ConfigurationError
+from .k8s_client import K8sConfig
+from .truenas_client import TrueNASConfig
 
 
 class Config:
@@ -65,8 +68,13 @@ class Config:
 
     @property
     def openshift(self) -> Dict[str, Any]:
-        """Get OpenShift configuration."""
+        """Get OpenShift/Kubernetes cluster configuration."""
         return self.get("openshift", {})
+
+    @property
+    def kubernetes(self) -> Dict[str, Any]:
+        """Deprecated alias for :attr:`openshift`."""
+        return self.openshift
 
     @property
     def monitoring(self) -> Dict[str, Any]:
@@ -77,6 +85,72 @@ class Config:
     def logging(self) -> Dict[str, Any]:
         """Get logging configuration."""
         return self.get("logging", {})
+
+    def k8s_config(self) -> K8sConfig:
+        """Build typed Kubernetes client configuration."""
+        cluster = self.openshift
+        return K8sConfig(
+            kubeconfig=cluster.get("kubeconfig"),
+            namespace=cluster.get("namespace"),
+            csi_driver=cluster.get("csi_driver", "org.democratic-csi.nfs"),
+            storage_class=cluster.get("storage_class"),
+            in_cluster=cluster.get("in_cluster", False),
+        )
+
+    def truenas_config(self) -> TrueNASConfig:
+        """Build typed TrueNAS client configuration."""
+        truenas = self.truenas
+        host, port = parse_truenas_url(truenas["url"])
+        insecure = truenas.get("insecure", False)
+        return TrueNASConfig(
+            host=host,
+            port=port,
+            api_key=truenas.get("api_key"),
+            username=truenas.get("username"),
+            password=truenas.get("password"),
+            verify_ssl=not insecure,
+            timeout=parse_timeout_seconds(truenas.get("timeout", 30)),
+            max_retries=truenas.get("max_retries", 3),
+        )
+
+
+def parse_truenas_url(url: str) -> Tuple[str, int]:
+    """Parse a TrueNAS URL into host and port."""
+    normalized = url if "://" in url else f"https://{url}"
+    parsed = urlparse(normalized)
+    host = parsed.hostname or url
+    if parsed.port is not None:
+        port = parsed.port
+    elif parsed.scheme == "http":
+        port = 80
+    else:
+        port = 443
+    return host, port
+
+
+def parse_timeout_seconds(value: Any) -> int:
+    """Parse timeout values such as 30 or '30s' into seconds."""
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped.endswith("s"):
+            return int(stripped[:-1])
+        return int(stripped)
+    raise ConfigurationError(f"Invalid timeout value: {value!r}")
+
+
+def normalize_cluster_config(config: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize legacy ``kubernetes`` section to canonical ``openshift``."""
+    if "kubernetes" not in config:
+        return config
+
+    kubernetes = config.pop("kubernetes")
+    if "openshift" not in config:
+        config["openshift"] = kubernetes
+    else:
+        config["openshift"] = merge_configs(kubernetes, config["openshift"])
+    return config
 
 
 def load_config(config_path: Optional[str] = None) -> Dict[str, Any]:
@@ -123,6 +197,7 @@ def load_config(config_path: Optional[str] = None) -> Dict[str, Any]:
 
     # Expand environment variables
     config = expand_env_vars(config)
+    config = normalize_cluster_config(config)
 
     # Validate configuration
     validate_config(config)
@@ -206,6 +281,8 @@ def validate_config(config: Dict[str, Any]) -> None:
     Raises:
         ConfigurationError: If configuration is invalid
     """
+    config = normalize_cluster_config(config.copy())
+
     # Check required sections
     required_sections = ["openshift", "monitoring"]
     for section in required_sections:

--- a/python/truenas_storage_monitor/config.py
+++ b/python/truenas_storage_monitor/config.py
@@ -100,7 +100,9 @@ class Config:
     def truenas_config(self) -> TrueNASConfig:
         """Build typed TrueNAS client configuration."""
         truenas = self.truenas
-        host, port = parse_truenas_url(truenas["url"])
+        if "url" not in truenas:
+            raise ConfigurationError("TrueNAS URL is required")
+        host, port, use_https = parse_truenas_url(truenas["url"])
         insecure = truenas.get("insecure", False)
         return TrueNASConfig(
             host=host,
@@ -109,35 +111,50 @@ class Config:
             username=truenas.get("username"),
             password=truenas.get("password"),
             verify_ssl=not insecure,
+            use_https=use_https,
             timeout=parse_timeout_seconds(truenas.get("timeout", 30)),
             max_retries=truenas.get("max_retries", 3),
         )
 
 
-def parse_truenas_url(url: str) -> Tuple[str, int]:
-    """Parse a TrueNAS URL into host and port."""
+def parse_truenas_url(url: str) -> Tuple[str, int, bool]:
+    """Parse a TrueNAS URL into host, port, and TLS scheme flag."""
     normalized = url if "://" in url else f"https://{url}"
-    parsed = urlparse(normalized)
-    host = parsed.hostname or url
-    if parsed.port is not None:
-        port = parsed.port
-    elif parsed.scheme == "http":
-        port = 80
-    else:
-        port = 443
-    return host, port
+    try:
+        parsed = urlparse(normalized)
+        host = parsed.hostname
+        if not host:
+            raise ConfigurationError(f"Invalid TrueNAS URL: {url!r}")
+        if parsed.port is not None:
+            port = parsed.port
+        elif parsed.scheme == "http":
+            port = 80
+        else:
+            port = 443
+        use_https = parsed.scheme != "http"
+        return host, port, use_https
+    except ValueError as exc:
+        raise ConfigurationError(f"Invalid TrueNAS URL: {url!r}") from exc
 
 
 def parse_timeout_seconds(value: Any) -> int:
     """Parse timeout values such as 30 or '30s' into seconds."""
-    if isinstance(value, int):
-        return value
-    if isinstance(value, str):
-        stripped = value.strip()
-        if stripped.endswith("s"):
-            return int(stripped[:-1])
-        return int(stripped)
-    raise ConfigurationError(f"Invalid timeout value: {value!r}")
+    if isinstance(value, bool):
+        raise ConfigurationError(f"Invalid timeout value: {value!r}")
+    try:
+        if isinstance(value, int):
+            seconds = value
+        elif isinstance(value, str):
+            stripped = value.strip()
+            seconds = int(stripped[:-1]) if stripped.endswith("s") else int(stripped)
+        else:
+            raise TypeError
+    except (TypeError, ValueError) as exc:
+        raise ConfigurationError(f"Invalid timeout value: {value!r}") from exc
+
+    if seconds <= 0:
+        raise ConfigurationError(f"Timeout must be > 0 seconds: {value!r}")
+    return seconds
 
 
 def normalize_cluster_config(config: Dict[str, Any]) -> Dict[str, Any]:
@@ -145,11 +162,17 @@ def normalize_cluster_config(config: Dict[str, Any]) -> Dict[str, Any]:
     if "kubernetes" not in config:
         return config
 
-    kubernetes = config.pop("kubernetes")
+    kubernetes = config.pop("kubernetes") or {}
+    if not isinstance(kubernetes, dict):
+        raise ConfigurationError("The 'kubernetes' section must be a mapping")
+
     if "openshift" not in config:
         config["openshift"] = kubernetes
     else:
-        config["openshift"] = merge_configs(kubernetes, config["openshift"])
+        openshift = config["openshift"] or {}
+        if not isinstance(openshift, dict):
+            raise ConfigurationError("The 'openshift' section must be a mapping")
+        config["openshift"] = merge_configs(kubernetes, openshift)
     return config
 
 

--- a/python/truenas_storage_monitor/k8s_client.py
+++ b/python/truenas_storage_monitor/k8s_client.py
@@ -47,6 +47,7 @@ class PersistentVolumeInfo:
     capacity: str
     access_modes: List[str]
     phase: str
+    storage_class: Optional[str] = None
     claim_ref: Optional[Dict[str, str]] = None
     creation_time: Optional[datetime] = None
     labels: Dict[str, str] = field(default_factory=dict)
@@ -167,6 +168,7 @@ class K8sClient:
                         capacity=pv.spec.capacity.get("storage", ""),
                         access_modes=pv.spec.access_modes,
                         phase=pv.status.phase,
+                        storage_class=pv.spec.storage_class_name,
                         claim_ref=claim_ref,
                         creation_time=pv.metadata.creation_timestamp,
                         labels=pv.metadata.labels or {},
@@ -465,7 +467,7 @@ class K8sClient:
                     name=pv.name,
                     namespace=None,
                     volume_handle=pv.volume_handle,
-                    creation_time=pv.creation_time or utc_now(),
+                    creation_time=(ensure_utc(pv.creation_time) if pv.creation_time else utc_now()),
                     size=pv.capacity,
                     location="Kubernetes",
                     reason="No PVC bound" if pv.phase == "Available" else "PVC deleted",
@@ -497,12 +499,13 @@ class K8sClient:
             if pvc.phase != "Pending" or pvc.creation_time is None:
                 continue
             if ensure_utc(pvc.creation_time) < threshold:
+                creation_time = ensure_utc(pvc.creation_time)
                 orphan = OrphanedResource(
                     resource_type=ResourceType.PERSISTENT_VOLUME_CLAIM,
                     name=pvc.name,
                     namespace=pvc.namespace,
                     volume_handle=None,
-                    creation_time=pvc.creation_time,
+                    creation_time=creation_time,
                     size=pvc.capacity,
                     location="Kubernetes",
                     reason=f"Pending for over {pending_threshold_minutes} minutes",

--- a/python/truenas_storage_monitor/k8s_client.py
+++ b/python/truenas_storage_monitor/k8s_client.py
@@ -9,6 +9,8 @@ from typing import List, Dict, Optional, Any, Generator
 from kubernetes import client as k8s_client, config, watch
 from kubernetes.client.rest import ApiException
 
+from .time_utils import ensure_utc, utc_now
+
 logger = logging.getLogger(__name__)
 
 
@@ -116,6 +118,27 @@ class K8sClient:
         self.core_v1 = k8s_client.CoreV1Api()
         self.storage_v1 = k8s_client.StorageV1Api()
         self.custom_objects = k8s_client.CustomObjectsApi()
+
+    def test_connection(self) -> bool:
+        """Verify connectivity to the Kubernetes API server."""
+        try:
+            self.core_v1.list_namespace(limit=1)
+            logger.info("Successfully connected to Kubernetes API")
+            return True
+        except ApiException as e:
+            logger.error(f"Failed to connect to Kubernetes API: {e}")
+            raise
+
+    def list_namespaces(self) -> List[str]:
+        """List all namespace names in the cluster."""
+        try:
+            namespaces = self.core_v1.list_namespace()
+            names = [item.metadata.name for item in namespaces.items]
+            logger.info(f"Found {len(names)} namespaces")
+            return names
+        except ApiException as e:
+            logger.error(f"Failed to list namespaces: {e}")
+            raise
 
     def get_persistent_volumes(self) -> List[PersistentVolumeInfo]:
         """Get all PersistentVolumes managed by the CSI driver.
@@ -442,7 +465,7 @@ class K8sClient:
                     name=pv.name,
                     namespace=None,
                     volume_handle=pv.volume_handle,
-                    creation_time=pv.creation_time or datetime.now(),
+                    creation_time=pv.creation_time or utc_now(),
                     size=pv.capacity,
                     location="Kubernetes",
                     reason="No PVC bound" if pv.phase == "Available" else "PVC deleted",
@@ -468,12 +491,12 @@ class K8sClient:
         """
         orphans = []
         pvcs = self.get_persistent_volume_claims()
-        threshold = datetime.now(
-            tz=pvcs[0].creation_time.tzinfo if pvcs and pvcs[0].creation_time else None
-        ) - timedelta(minutes=pending_threshold_minutes)
+        threshold = utc_now() - timedelta(minutes=pending_threshold_minutes)
 
         for pvc in pvcs:
-            if pvc.phase == "Pending" and pvc.creation_time and pvc.creation_time < threshold:
+            if pvc.phase != "Pending" or pvc.creation_time is None:
+                continue
+            if ensure_utc(pvc.creation_time) < threshold:
                 orphan = OrphanedResource(
                     resource_type=ResourceType.PERSISTENT_VOLUME_CLAIM,
                     name=pvc.name,
@@ -520,7 +543,7 @@ class K8sClient:
                         "name": pv.metadata.name,
                         "volume_handle": pv.spec.csi.volume_handle,
                         "phase": pv.status.phase,
-                        "timestamp": datetime.now(),
+                        "timestamp": utc_now(),
                     }
         finally:
             w.stop()
@@ -569,7 +592,7 @@ class K8sClient:
                     "namespace": pvc.metadata.namespace,
                     "phase": pvc.status.phase,
                     "volume_name": pvc.spec.volume_name,
-                    "timestamp": datetime.now(),
+                    "timestamp": utc_now(),
                 }
         finally:
             w.stop()

--- a/python/truenas_storage_monitor/monitor.py
+++ b/python/truenas_storage_monitor/monitor.py
@@ -91,7 +91,7 @@ class Monitor:
                         "age": age,
                         "reason": "No corresponding TrueNAS volume found",
                         "size": pv.capacity or "Unknown",
-                        "storage_class": "Unknown",
+                        "storage_class": pv.storage_class or "Unknown",
                     }
                 )
 

--- a/python/truenas_storage_monitor/monitor.py
+++ b/python/truenas_storage_monitor/monitor.py
@@ -1,13 +1,19 @@
 """Core monitoring functionality."""
 
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 from typing import Dict, List, Optional, Any
 
-from .k8s_client import K8sClient
-from .truenas_client import TrueNASClient
+from .k8s_client import (
+    K8sClient,
+    PersistentVolumeClaimInfo,
+    PersistentVolumeInfo,
+    VolumeSnapshotInfo,
+)
+from .truenas_client import TrueNASClient, VolumeInfo, SnapshotInfo
 from .config import Config
 from .exceptions import TrueNASMonitorError
+from .time_utils import ensure_utc, resource_age, utc_now
 
 logger = logging.getLogger(__name__)
 
@@ -18,8 +24,8 @@ class Monitor:
     def __init__(self, config: Config):
         """Initialize the monitor with configuration."""
         self.config = config
-        self.k8s_client = K8sClient(config.kubernetes)
-        self.truenas_client = TrueNASClient(config.truenas)
+        self.k8s_client = K8sClient(config.k8s_config())
+        self.truenas_client = TrueNASClient(config.truenas_config())
 
     def find_orphaned_resources(
         self, namespace: Optional[str] = None, age_threshold_hours: int = 24
@@ -28,15 +34,13 @@ class Monitor:
         logger.info(f"Scanning for orphaned resources (threshold: {age_threshold_hours}h)")
 
         try:
-            # Get resources from both systems
-            k8s_pvs = self.k8s_client.list_persistent_volumes()
-            k8s_pvcs = self.k8s_client.list_persistent_volume_claims(namespace)
-            k8s_snapshots = self.k8s_client.list_volume_snapshots(namespace)
+            k8s_pvs = self.k8s_client.get_persistent_volumes()
+            k8s_pvcs = self.k8s_client.get_persistent_volume_claims(namespace)
+            k8s_snapshots = self.k8s_client.get_volume_snapshots(namespace)
 
-            truenas_volumes = self.truenas_client.list_volumes()
-            truenas_snapshots = self.truenas_client.list_snapshots()
+            truenas_volumes = self.truenas_client.get_volumes()
+            truenas_snapshots = self.truenas_client.get_snapshots()
 
-            # Find orphaned resources
             orphaned_pvs = self._find_orphaned_pvs(k8s_pvs, truenas_volumes, age_threshold_hours)
             orphaned_pvcs = self._find_orphaned_pvcs(k8s_pvcs, age_threshold_hours)
             orphaned_snapshots = self._find_orphaned_snapshots(
@@ -44,7 +48,7 @@ class Monitor:
             )
 
             return {
-                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "timestamp": utc_now().isoformat(),
                 "orphaned_pvs": orphaned_pvs,
                 "orphaned_pvcs": orphaned_pvcs,
                 "orphaned_snapshots": orphaned_snapshots,
@@ -59,133 +63,126 @@ class Monitor:
             raise TrueNASMonitorError(f"Failed to scan for orphaned resources: {e}")
 
     def _find_orphaned_pvs(
-        self, k8s_pvs: List[Dict], truenas_volumes: List[Dict], age_threshold_hours: int
+        self,
+        k8s_pvs: List[PersistentVolumeInfo],
+        truenas_volumes: List[VolumeInfo],
+        age_threshold_hours: int,
     ) -> List[Dict]:
         """Find PVs without corresponding TrueNAS volumes."""
         orphaned = []
-        threshold = datetime.now(timezone.utc) - timedelta(hours=age_threshold_hours)
+        threshold = utc_now() - timedelta(hours=age_threshold_hours)
 
         for pv in k8s_pvs:
-            # Check if PV is from democratic-csi
             if not self._is_democratic_csi_pv(pv):
                 continue
 
-            # Check age
-            created_str = pv.get("metadata", {}).get("creationTimestamp", "")
-            if created_str:
-                created = datetime.fromisoformat(created_str.replace("Z", "+00:00"))
-                if created > threshold:
-                    continue
+            if pv.creation_time is None:
+                continue
 
-                # Check if corresponding TrueNAS volume exists
-                if not self._has_corresponding_truenas_volume(pv, truenas_volumes):
-                    orphaned.append(
-                        {
-                            "name": pv["metadata"]["name"],
-                            "age": str(datetime.now(timezone.utc) - created),
-                            "reason": "No corresponding TrueNAS volume found",
-                            "size": pv.get("spec", {})
-                            .get("capacity", {})
-                            .get("storage", "Unknown"),
-                            "storage_class": pv.get("spec", {}).get("storageClassName", "Unknown"),
-                        }
-                    )
+            created = ensure_utc(pv.creation_time)
+            if created > threshold:
+                continue
+
+            if not self._has_corresponding_truenas_volume(pv, truenas_volumes):
+                age = resource_age(created)
+                orphaned.append(
+                    {
+                        "name": pv.name,
+                        "age": age,
+                        "reason": "No corresponding TrueNAS volume found",
+                        "size": pv.capacity or "Unknown",
+                        "storage_class": "Unknown",
+                    }
+                )
 
         return orphaned
 
-    def _find_orphaned_pvcs(self, k8s_pvcs: List[Dict], age_threshold_hours: int) -> List[Dict]:
+    def _find_orphaned_pvcs(
+        self, k8s_pvcs: List[PersistentVolumeClaimInfo], age_threshold_hours: int
+    ) -> List[Dict]:
         """Find unbound PVCs older than threshold."""
         orphaned = []
-        threshold = datetime.now(timezone.utc) - timedelta(hours=age_threshold_hours)
+        threshold = utc_now() - timedelta(hours=age_threshold_hours)
 
         for pvc in k8s_pvcs:
-            # Check if PVC is pending/unbound
-            if pvc.get("status", {}).get("phase") != "Pending":
+            if pvc.phase != "Pending" or pvc.creation_time is None:
                 continue
 
-            # Check age
-            created_str = pvc.get("metadata", {}).get("creationTimestamp", "")
-            if created_str:
-                created = datetime.fromisoformat(created_str.replace("Z", "+00:00"))
-                if created <= threshold:
-                    orphaned.append(
-                        {
-                            "name": pvc["metadata"]["name"],
-                            "namespace": pvc["metadata"]["namespace"],
-                            "age": str(datetime.now(timezone.utc) - created),
-                            "reason": f"Unbound for {datetime.now(timezone.utc) - created}",
-                            "size": pvc.get("spec", {})
-                            .get("resources", {})
-                            .get("requests", {})
-                            .get("storage", "Unknown"),
-                            "storage_class": pvc.get("spec", {}).get("storageClassName", "Unknown"),
-                        }
-                    )
+            created = ensure_utc(pvc.creation_time)
+            if created <= threshold:
+                age = resource_age(created)
+                orphaned.append(
+                    {
+                        "name": pvc.name,
+                        "namespace": pvc.namespace,
+                        "age": age,
+                        "reason": f"Unbound for {age}",
+                        "size": pvc.capacity or "Unknown",
+                        "storage_class": pvc.storage_class or "Unknown",
+                    }
+                )
 
         return orphaned
 
     def _find_orphaned_snapshots(
-        self, k8s_snapshots: List[Dict], truenas_snapshots: List[Dict], age_threshold_hours: int
+        self,
+        k8s_snapshots: List[VolumeSnapshotInfo],
+        truenas_snapshots: List[SnapshotInfo],
+        age_threshold_hours: int,
     ) -> List[Dict]:
         """Find snapshots without corresponding TrueNAS snapshots."""
         orphaned = []
-        threshold = datetime.now(timezone.utc) - timedelta(hours=age_threshold_hours)
+        threshold = utc_now() - timedelta(hours=age_threshold_hours)
 
         for snapshot in k8s_snapshots:
-            # Check age
-            created_str = snapshot.get("metadata", {}).get("creationTimestamp", "")
-            if created_str:
-                created = datetime.fromisoformat(created_str.replace("Z", "+00:00"))
-                if created > threshold:
-                    continue
+            if snapshot.creation_time is None:
+                continue
 
-                # Check if corresponding TrueNAS snapshot exists
-                if not self._has_corresponding_truenas_snapshot(snapshot, truenas_snapshots):
-                    orphaned.append(
-                        {
-                            "name": snapshot["metadata"]["name"],
-                            "namespace": snapshot["metadata"]["namespace"],
-                            "age": str(datetime.now(timezone.utc) - created),
-                            "reason": "No corresponding TrueNAS snapshot found",
-                            "source_pvc": snapshot.get("spec", {})
-                            .get("source", {})
-                            .get("persistentVolumeClaimName", "Unknown"),
-                        }
-                    )
+            created = ensure_utc(snapshot.creation_time)
+            if created > threshold:
+                continue
+
+            if not self._has_corresponding_truenas_snapshot(snapshot, truenas_snapshots):
+                orphaned.append(
+                    {
+                        "name": snapshot.name,
+                        "namespace": snapshot.namespace,
+                        "age": resource_age(created),
+                        "reason": "No corresponding TrueNAS snapshot found",
+                        "source_pvc": snapshot.source_pvc or "Unknown",
+                    }
+                )
 
         return orphaned
 
-    def _is_democratic_csi_pv(self, pv: Dict) -> bool:
+    def _is_democratic_csi_pv(self, pv: PersistentVolumeInfo) -> bool:
         """Check if PV is managed by democratic-csi."""
-        csi_driver = pv.get("spec", {}).get("csi", {}).get("driver", "")
-        return "democratic-csi" in csi_driver or "truenas" in csi_driver.lower()
+        driver = pv.driver or ""
+        return "democratic-csi" in driver or "truenas" in driver.lower()
 
-    def _has_corresponding_truenas_volume(self, pv: Dict, truenas_volumes: List[Dict]) -> bool:
+    def _has_corresponding_truenas_volume(
+        self, pv: PersistentVolumeInfo, truenas_volumes: List[VolumeInfo]
+    ) -> bool:
         """Check if PV has corresponding TrueNAS volume."""
-        # Extract volume handle from PV
-        volume_handle = pv.get("spec", {}).get("csi", {}).get("volumeHandle", "")
+        volume_handle = pv.volume_handle
         if not volume_handle:
             return False
 
-        # Look for matching TrueNAS volume
         for volume in truenas_volumes:
-            if volume.get("name") in volume_handle or volume_handle in volume.get("name", ""):
+            if volume.name in volume_handle or volume_handle in volume.name:
                 return True
 
         return False
 
     def _has_corresponding_truenas_snapshot(
-        self, snapshot: Dict, truenas_snapshots: List[Dict]
+        self, snapshot: VolumeSnapshotInfo, truenas_snapshots: List[SnapshotInfo]
     ) -> bool:
         """Check if K8s snapshot has corresponding TrueNAS snapshot."""
-        snapshot_name = snapshot["metadata"]["name"]
+        snapshot_name = snapshot.name
 
-        # Look for matching TrueNAS snapshot
         for truenas_snapshot in truenas_snapshots:
-            if (
-                snapshot_name in truenas_snapshot.get("name", "")
-                or truenas_snapshot.get("name", "") in snapshot_name
-            ):
+            names = {truenas_snapshot.name, truenas_snapshot.full_name}
+            if any(name and (snapshot_name in name or name in snapshot_name) for name in names):
                 return True
 
         return False
@@ -197,18 +194,11 @@ class Monitor:
         logger.info(f"Analyzing storage usage for {days} days")
 
         try:
-            # Get current storage data
-            pvcs = self.k8s_client.list_persistent_volume_claims(namespace)
-            pvs = self.k8s_client.list_persistent_volumes()
-            truenas_volumes = self.truenas_client.list_volumes()
+            pvcs = self.k8s_client.get_persistent_volume_claims(namespace)
+            pvs = self.k8s_client.get_persistent_volumes()
+            truenas_volumes = self.truenas_client.get_volumes()
 
-            # Calculate metrics
-            total_allocated = sum(
-                self._parse_storage_size(
-                    pvc.get("spec", {}).get("resources", {}).get("requests", {}).get("storage", "0")
-                )
-                for pvc in pvcs
-            )
+            total_allocated = sum(self._parse_storage_size(pvc.capacity or "0") for pvc in pvcs)
             total_used = sum(self._get_volume_used_space(vol) for vol in truenas_volumes)
 
             efficiency = (
@@ -252,28 +242,24 @@ class Monitor:
 
         return int(size_str) if size_str.isdigit() else 0
 
-    def _get_volume_used_space(self, volume: Dict) -> int:
+    def _get_volume_used_space(self, volume: VolumeInfo) -> int:
         """Get used space for a TrueNAS volume."""
-        # This would need to be implemented based on TrueNAS API response format
-        return volume.get("used_bytes", 0)
+        return volume.size
 
-    def _generate_recommendations(self, pvcs: List[Dict], truenas_volumes: List[Dict]) -> List[str]:
+    def _generate_recommendations(
+        self, pvcs: List[PersistentVolumeClaimInfo], truenas_volumes: List[VolumeInfo]
+    ) -> List[str]:
         """Generate storage optimization recommendations."""
         recommendations = []
 
-        # Check for oversized PVCs
         for pvc in pvcs:
-            requested = self._parse_storage_size(
-                pvc.get("spec", {}).get("resources", {}).get("requests", {}).get("storage", "0")
-            )
-            if requested > 100 * 1024**3:  # > 100GB
-                pvc_name = pvc["metadata"]["name"]
+            requested = self._parse_storage_size(pvc.capacity or "0")
+            if requested > 100 * 1024**3:
                 size_gb = requested / 1024**3
                 recommendations.append(
-                    f"Consider reviewing large PVC: {pvc_name} ({size_gb:.1f}GB)"
+                    f"Consider reviewing large PVC: {pvc.name} ({size_gb:.1f}GB)"
                 )
 
-        # Check for unused volumes
         if len(truenas_volumes) > len(pvcs):
             recommendations.append(
                 f"Found {len(truenas_volumes) - len(pvcs)} potentially unused TrueNAS volumes"
@@ -291,7 +277,7 @@ class Monitor:
             health = self.check_health()
 
             return {
-                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "timestamp": utc_now().isoformat(),
                 "summary": {
                     "total_orphaned_resources": len(orphans["orphaned_pvs"])
                     + len(orphans["orphaned_pvcs"])
@@ -315,25 +301,22 @@ class Monitor:
 
         results = {}
 
-        # Test Kubernetes connection
         try:
             self.k8s_client.test_connection()
             results["kubernetes"] = {"valid": True, "message": "Connection successful"}
         except Exception as e:
             results["kubernetes"] = {"valid": False, "message": str(e)}
 
-        # Test TrueNAS connection
         try:
             self.truenas_client.test_connection()
             results["truenas"] = {"valid": True, "message": "Connection successful"}
         except Exception as e:
             results["truenas"] = {"valid": False, "message": str(e)}
 
-        # Check democratic-csi namespace
         try:
             namespaces = self.k8s_client.list_namespaces()
-            csi_namespace = self.config.kubernetes.get("namespace", "democratic-csi")
-            if any(ns["metadata"]["name"] == csi_namespace for ns in namespaces):
+            csi_namespace = self.config.openshift.get("namespace", "democratic-csi")
+            if csi_namespace in namespaces:
                 results["democratic_csi"] = {
                     "valid": True,
                     "message": f"Namespace {csi_namespace} found",
@@ -354,46 +337,31 @@ class Monitor:
 
         components = {}
 
-        # Check Kubernetes health
         try:
             self.k8s_client.test_connection()
             components["kubernetes"] = {"healthy": True, "message": "API server accessible"}
         except Exception as e:
             components["kubernetes"] = {"healthy": False, "message": str(e)}
 
-        # Check TrueNAS health
         try:
             self.truenas_client.test_connection()
             components["truenas"] = {"healthy": True, "message": "API accessible"}
         except Exception as e:
             components["truenas"] = {"healthy": False, "message": str(e)}
 
-        # Check CSI driver health
         try:
-            csi_pods = self.k8s_client.list_pods(
-                namespace=self.config.kubernetes.get("namespace", "democratic-csi")
-            )
-            healthy_pods = [
-                pod for pod in csi_pods if pod.get("status", {}).get("phase") == "Running"
-            ]
-            if healthy_pods:
-                components["csi_driver"] = {
-                    "healthy": True,
-                    "message": f"{len(healthy_pods)} CSI pods running",
-                }
-            else:
-                components["csi_driver"] = {
-                    "healthy": False,
-                    "message": "No healthy CSI pods found",
-                }
+            csi_health = self.k8s_client.check_csi_driver_health()
+            components["csi_driver"] = {
+                "healthy": csi_health["healthy"],
+                "message": csi_health.get("reason", "CSI driver health unknown"),
+            }
         except Exception as e:
             components["csi_driver"] = {"healthy": False, "message": str(e)}
 
-        # Overall health
         overall_healthy = all(comp["healthy"] for comp in components.values())
 
         return {
             "healthy": overall_healthy,
             "components": components,
-            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "timestamp": utc_now().isoformat(),
         }

--- a/python/truenas_storage_monitor/time_utils.py
+++ b/python/truenas_storage_monitor/time_utils.py
@@ -1,0 +1,36 @@
+"""Timezone-aware datetime helpers."""
+
+from datetime import datetime, timezone
+from typing import Optional
+
+
+def utc_now() -> datetime:
+    """Return the current time as a timezone-aware UTC datetime."""
+    return datetime.now(timezone.utc)
+
+
+def ensure_utc(dt: datetime) -> datetime:
+    """Return a timezone-aware UTC datetime.
+
+    Naive datetimes are treated as UTC.
+    """
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def parse_rfc3339(value: str) -> datetime:
+    """Parse an RFC3339 / Kubernetes timestamp into aware UTC."""
+    if not value:
+        raise ValueError("timestamp value must not be empty")
+
+    normalized = value.replace("Z", "+00:00")
+    parsed = datetime.fromisoformat(normalized)
+    return ensure_utc(parsed)
+
+
+def resource_age(created: Optional[datetime]) -> Optional[str]:
+    """Format age string for a resource creation time."""
+    if created is None:
+        return None
+    return str(utc_now() - ensure_utc(created))

--- a/python/truenas_storage_monitor/truenas_client.py
+++ b/python/truenas_storage_monitor/truenas_client.py
@@ -37,6 +37,7 @@ class TrueNASConfig:
     username: Optional[str] = None
     password: Optional[str] = None
     verify_ssl: bool = True
+    use_https: bool = True
     timeout: int = 30
     max_retries: int = 3
 
@@ -48,7 +49,7 @@ class TrueNASConfig:
     @property
     def base_url(self) -> str:
         """Get the base URL for TrueNAS API."""
-        protocol = "https" if self.port == 443 else "http"
+        protocol = "https" if self.use_https else "http"
         return f"{protocol}://{self.host}:{self.port}/api/v2.0"
 
 


### PR DESCRIPTION
## Summary

- Align `Monitor` with typed `K8sConfig`/`TrueNASConfig` factories and real `get_*` client APIs (replacing stale `list_*` calls and dict-shaped assumptions).
- Normalize `kubernetes` → `openshift` config sections at load time; add shared UTC datetime helpers and fix naive/aware comparison bugs in the K8s client.
- Update unit tests to catch contract drift (dataclass fixtures, timezone edge cases, factory wiring).

**Spec:** [docs/superpowers/specs/2026-05-28-pr-2-python-correctness-design.md](docs/superpowers/specs/2026-05-28-pr-2-python-correctness-design.md)

**Plan item:** PR 2 in [docs/superpowers/plans/2026-05-28-repo-health-remediation.md](docs/superpowers/plans/2026-05-28-repo-health-remediation.md)

## Mandatory PR checklist

- [x] **Scope:** Maps to one plan item (PR 2).
- [x] **Correctness:** Added/updated tests for changed logic.
- [x] **Regression Safety:** Relevant existing tests pass (76/76).
- [x] **Security:** No insecure defaults introduced; secrets not exposed.
- [x] **Reliability:** Failure paths handled; datetime comparisons are UTC-aware.
- [x] **Performance:** No obvious unbounded loops/maps or avoidable N^2 regressions.
- [ ] **Docs:** Config behavior unchanged in user-facing YAML; deploy manifest rename deferred to PR-8.
- [ ] **Ops/Runbook:** No operational behavior change requiring runbook update.
- [x] **Verification Evidence:** See test plan below.
- [x] **Tracking:** Plan status/checklists updated.

## Test plan

- [x] `cd python && pytest tests/unit/test_config.py tests/unit/test_monitor.py tests/unit/test_k8s_client.py tests/unit/test_time_utils.py -v` — 57 passed
- [x] `make python-test` — 76 passed (coverage gate 90% still pre-existing: 76.48% vs 74.37% on main)
- [x] `mypy` on changed source files — success
- [ ] `make python-lint` — flake8 E501 pre-existing repo-wide (main also fails)
- [ ] `bandit` — not installed locally; CI to verify

## Review notes

- CodeRabbit review initiated but did not complete within session timeout; manual review performed on diff prior to commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OpenShift config with Kubernetes aliasing, API connection check, namespace listing, TrueNAS HTTPS option, and UTC-based timestamps/reporting

* **Bug Fixes**
  * Timezone-aware datetime handling, normalized comparisons, improved orphan detection and age calculations, and stricter TrueNAS URL/timeout parsing

* **Tests**
  * Expanded unit tests for config parsing, time utilities, client connectivity, orphan detection, health checks, and recommendations

* **Documentation**
  * Added design spec for PR 2 and updated remediation plan statuses

* **Refactor**
  * Monitoring workflow switched to typed clients and centralized UTC helpers

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tomazb/kubernetes-truenas-democratic-tool/pull/52?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->