### PR TITLE
PR-4: API honesty and endpoint maturity cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,8 @@ make docker-build-all
 - [CLAUDE.md](CLAUDE.md) - Pointer to AGENTS.md (legacy entry point)
 - [Remediation plan](docs/superpowers/plans/2026-05-28-repo-health-remediation.md) - Phased repo health work
 - [Backlog](docs/superpowers/backlog.md) - Canonical out-of-scope intake
-- [API Reference](https://yourusername.github.io/kubernetes-truenas-democratic-tool/)
+- [API endpoint maturity](docs/api-endpoints.md) - Implemented vs 501 routes for the Go API server
+- [API Reference](https://yourusername.github.io/kubernetes-truenas-democratic-tool/) - Planned external docs (placeholder)
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ make docker-build-all
 - [Remediation plan](docs/superpowers/plans/2026-05-28-repo-health-remediation.md) - Phased repo health work
 - [Backlog](docs/superpowers/backlog.md) - Canonical out-of-scope intake
 - [API endpoint maturity](docs/api-endpoints.md) - Implemented vs 501 routes for the Go API server
-- [API Reference](https://yourusername.github.io/kubernetes-truenas-democratic-tool/) - Planned external docs (placeholder)
+- API Reference (planned external docs): TBD
 
 ## Security
 

--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -1,0 +1,74 @@
+# API Endpoint Maturity
+
+This document describes the current maturity of HTTP routes exposed by the Go API server (`cmd/api-server`).
+
+Orphan detection runs synchronously on each request for implemented orphan routes. Detection quality continues to improve in PR-5 (detector fidelity).
+
+## Infrastructure
+
+| Route | Status | Notes |
+|-------|--------|-------|
+| `GET /health` | Implemented | Process liveness |
+| `GET /ready` | Implemented | Kubernetes + TrueNAS connectivity |
+
+## Orphan detection
+
+| Route | Status | Notes |
+|-------|--------|-------|
+| `GET /api/v1/orphans` | Implemented | Sync `orphan.Detector`; query: `namespace`, `age_threshold` (default `24h`) |
+| `GET /api/v1/orphans/pvs` | Implemented | PV orphan subset; query: `age_threshold` |
+| `GET /api/v1/orphans/pvcs` | Not implemented (501) | |
+| `GET /api/v1/orphans/snapshots` | Not implemented (501) | |
+
+## Resources
+
+| Route | Status | Notes |
+|-------|--------|-------|
+| `GET /api/v1/resources/pvs` | Implemented | Lists Kubernetes PVs |
+| `GET /api/v1/resources/pvcs` | Not implemented (501) | |
+| `GET /api/v1/resources/snapshots` | Not implemented (501) | |
+| `GET /api/v1/resources/storageclasses` | Not implemented (501) | |
+
+## TrueNAS
+
+| Route | Status | Notes |
+|-------|--------|-------|
+| `GET /api/v1/truenas/volumes` | Implemented | Lists TrueNAS volumes |
+| `GET /api/v1/truenas/snapshots` | Not implemented (501) | |
+| `GET /api/v1/truenas/pools` | Not implemented (501) | |
+| `GET /api/v1/truenas/info` | Not implemented (501) | |
+
+## Analysis
+
+| Route | Status |
+|-------|--------|
+| `GET /api/v1/analysis` | Not implemented (501) |
+| `GET /api/v1/analysis/usage` | Not implemented (501) |
+| `GET /api/v1/analysis/trends` | Not implemented (501) |
+
+## Validation
+
+| Route | Status | Notes |
+|-------|--------|-------|
+| `GET /api/v1/validate` | Implemented | Connectivity checks |
+| `GET /api/v1/validate/config` | Not implemented (501) | |
+| `GET /api/v1/validate/connectivity` | Not implemented (501) | |
+
+## Reports
+
+| Route | Status |
+|-------|--------|
+| `GET /api/v1/reports/summary` | Not implemented (501) |
+| `GET /api/v1/reports/detailed` | Not implemented (501) |
+
+## Unimplemented response contract
+
+Routes marked **Not implemented** return HTTP 501 with:
+
+```json
+{
+  "error": "not_implemented",
+  "message": "endpoint not implemented",
+  "endpoint": "/api/v1/..."
+}
+```

--- a/docs/superpowers/plans/2026-05-28-repo-health-remediation.md
+++ b/docs/superpowers/plans/2026-05-28-repo-health-remediation.md
@@ -257,7 +257,7 @@ Suggested worktree layout:
 - **Acceptance criteria:**
   - [x] No placeholder endpoint returns misleading success data.
   - [x] Endpoint maturity is explicit and test-verified.
-- **PR URL:** TBD
+- **PR URL:** https://github.com/tomazb/kubernetes-truenas-democratic-tool/pull/54
 
 ### PR 5: Orphan Detection and Validation Debt
 

--- a/docs/superpowers/plans/2026-05-28-repo-health-remediation.md
+++ b/docs/superpowers/plans/2026-05-28-repo-health-remediation.md
@@ -238,7 +238,7 @@ Suggested worktree layout:
 
 ### PR 4: API Honesty and Endpoint Maturity Cleanup
 
-- **Status:** Planned
+- **Status:** In Progress
 - **Risk:** High
 - **Focus:** Replace misleading placeholder success payloads.
 - **Branch/worktree:**
@@ -250,13 +250,13 @@ Suggested worktree layout:
   - `go/pkg/api/*_test.go`
   - API docs section in `README.md` or `docs/`
 - **Implementation steps:**
-  - [ ] Identify placeholder endpoints returning pseudo-success.
-  - [ ] Standardize unfinished endpoints to explicit `501` responses.
-  - [ ] Optionally implement one complete vertical slice endpoint (`/api/v1/orphans`).
-  - [ ] Add handler contract tests for implemented and unimplemented endpoints.
+  - [x] Identify placeholder endpoints returning pseudo-success.
+  - [x] Standardize unfinished endpoints to explicit `501` responses.
+  - [x] Optionally implement one complete vertical slice endpoint (`/api/v1/orphans`).
+  - [x] Add handler contract tests for implemented and unimplemented endpoints.
 - **Acceptance criteria:**
-  - [ ] No placeholder endpoint returns misleading success data.
-  - [ ] Endpoint maturity is explicit and test-verified.
+  - [x] No placeholder endpoint returns misleading success data.
+  - [x] Endpoint maturity is explicit and test-verified.
 - **PR URL:** TBD
 
 ### PR 5: Orphan Detection and Validation Debt

--- a/docs/superpowers/specs/2026-05-28-pr-4-api-honesty-design.md
+++ b/docs/superpowers/specs/2026-05-28-pr-4-api-honesty-design.md
@@ -1,0 +1,88 @@
+# PR 4: API Honesty and Endpoint Maturity Cleanup — Design Spec
+
+**Date:** 2026-05-28  
+**Plan item:** [Remediation plan PR 4](../plans/2026-05-28-repo-health-remediation.md)  
+**Milestone:** M2 — Contract Integrity
+
+## Problem statement and scope
+
+The Go API server exposes orphan endpoints that return HTTP 200 with empty orphan arrays and `total_orphans: 0`, implying a successful scan with no findings. That is misleading when no detection logic runs. Fourteen other routes already return HTTP 501, but with an inconsistent JSON envelope.
+
+Additionally, `NewServer` constructs a `monitor.Service` that is never started or used by handlers, while `orphan.Detector` already implements synchronous detection used by the monitor binary.
+
+**In scope:**
+
+- Wire `/api/v1/orphans` and `/api/v1/orphans/pvs` to `orphan.Detector.DetectOrphanedResources`
+- Remove unused `monitor.Service` wiring from the API server
+- Standardize HTTP 501 JSON envelope for unimplemented routes
+- Add `go/pkg/api/server_test.go` handler contract tests
+- Add minimal API maturity documentation (`docs/api-endpoints.md`)
+- Update remediation plan tracking
+
+**Out of scope:**
+
+- Detector matching fidelity (snapshot hardcoding, RBAC stubs) → PR-5
+- Implementing remaining 501 list/analysis/report endpoints → Stage 3 / later PRs
+- Full README endpoint overhaul → PR-8
+- Background monitor scans / rate-limiter refactor → PR-6
+
+## Current behavior vs target behavior
+
+| Aspect | Current | Target |
+|--------|---------|--------|
+| `GET /api/v1/orphans` | HTTP 200, empty arrays, no detection | HTTP 200 with real `orphan.DetectionResult` payload |
+| `GET /api/v1/orphans/pvs` | Lists PVs but always empty `orphaned_pvs` | HTTP 200 with detector PV subset |
+| Unimplemented routes | HTTP 501, `{"message":"not implemented"}` | HTTP 501 with `error`, `message`, `endpoint` fields |
+| API server monitor wiring | `monitor.Service` created, unused | Removed; orphan detection via `orphan.Detector` per request |
+| Handler tests | None | Contract tests for orphans, 501 routes, error paths |
+
+## Technical approach
+
+1. Remove `monitor.NewService` from `api.NewServer`.
+2. Add helper to parse `age_threshold` query (default `24h`) and run detection via per-request `orphan.NewDetector` (read-only `DryRun: true`).
+3. Map `DetectionResult` to JSON including `total_orphans` count.
+4. Replace 501 one-liners with shared `notImplemented(c, endpoint)` helper.
+5. Add httptest-based tests with stub `k8s.Client` / `truenas.Client` implementations.
+6. Document endpoint maturity in `docs/api-endpoints.md`.
+
+**Alternatives considered:**
+
+| Alternative | Decision |
+|-------------|----------|
+| Return 501 for orphan routes until PR-5 | Rejected — user chose wire to detector now |
+| Use `monitor.Service.GetLastScanResult()` | Rejected — requires background Start + metrics exporter |
+| Mutate shared detector config per request | Rejected — per-request construction avoids shared state |
+
+## Risk, failure modes, and mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Detector creates its own logger internally | Accept for PR-4; refactor in PR-5 if needed |
+| Synchronous scan latency on large clusters | Document behavior; cache/background scan deferred to PR-6 |
+| Clients expecting empty orphan arrays | Document breaking semantic fix in rollout notes |
+| Per-request detector overhead | Acceptable for honesty PR; optimize if profiling shows need |
+
+## Test strategy
+
+| Test | Purpose |
+|------|---------|
+| `TestListOrphansHandler_ReturnsDetectorResults` | Non-empty orphan signal when stubs provide aged unbound PV |
+| `TestListOrphansHandler_InvalidAgeThreshold_Returns400` | Bad `age_threshold` rejected |
+| `TestListOrphanedPVsHandler_ReturnsPVSubsetOnly` | PV endpoint returns PV orphan subset |
+| `TestListOrphansHandler_DetectorError_Returns500` | Upstream list failure surfaces as 500 |
+| `TestNotImplementedRoutes_Return501WithStandardEnvelope` | All stub routes return standardized 501 JSON |
+
+**Validation commands:**
+
+```bash
+cd go && go test ./pkg/api/... -v -cover
+cd go && go test ./... -v
+cd go && go vet ./...
+make go-lint
+```
+
+## Rollout and backout
+
+**Rollout:** Deploy updated API server. Orphan endpoints now perform real synchronous detection; clients may see non-zero orphan counts where previously always zero.
+
+**Backout:** Revert PR; orphan endpoints return to placeholder empty success responses (not recommended).

--- a/go/pkg/api/server.go
+++ b/go/pkg/api/server.go
@@ -15,7 +15,10 @@ import (
 	"golang.org/x/time/rate"
 )
 
-const defaultOrphanAgeThreshold = 24 * time.Hour
+const (
+	defaultOrphanAgeThreshold     = 24 * time.Hour
+	defaultOrphanAgeThresholdQuery = "24h"
+)
 
 // Server represents the API server
 type Server struct {
@@ -23,7 +26,7 @@ type Server struct {
 	k8sClient               k8s.Client
 	truenasClient           truenas.Client
 	logger                  *zap.Logger
-	orphanSnapshotRetention time.Duration
+	orphanDetector *orphan.Detector
 }
 
 // Config holds the server configuration
@@ -36,6 +39,18 @@ type Config struct {
 
 // NewServer creates a new API server with comprehensive middleware
 func NewServer(config Config) (*Server, error) {
+	if config.K8sClient == nil {
+		return nil, fmt.Errorf("k8sClient is required")
+	}
+	if config.TruenasClient == nil {
+		return nil, fmt.Errorf("truenasClient is required")
+	}
+
+	logger := config.Logger
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+
 	// Set Gin mode
 	gin.SetMode(gin.ReleaseMode)
 
@@ -52,16 +67,25 @@ func NewServer(config Config) (*Server, error) {
 	router.Use(requestIDMiddleware())
 
 	// Add logging middleware
-	router.Use(loggingMiddleware(config.Logger))
+	router.Use(loggingMiddleware(logger))
 
 	// Add rate limiting middleware
 	router.Use(rateLimitMiddleware())
 
+	orphanDetector, err := orphan.NewDetector(config.K8sClient, config.TruenasClient, orphan.Config{
+		AgeThreshold:      defaultOrphanAgeThreshold,
+		SnapshotRetention: 30 * 24 * time.Hour,
+		DryRun:            true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create orphan detector: %w", err)
+	}
+
 	server := &Server{
-		k8sClient:               config.K8sClient,
-		truenasClient:           config.TruenasClient,
-		logger:                  config.Logger,
-		orphanSnapshotRetention: 30 * 24 * time.Hour,
+		k8sClient:      config.K8sClient,
+		truenasClient:  config.TruenasClient,
+		logger:         logger,
+		orphanDetector: orphanDetector,
 	}
 
 	// Setup routes
@@ -143,28 +167,33 @@ func (s *Server) setupRoutes(router *gin.Engine) {
 }
 
 func (s *Server) parseAgeThreshold(c *gin.Context) (time.Duration, string, bool) {
-	ageThreshold := c.DefaultQuery("age_threshold", defaultOrphanAgeThreshold.String())
-	parsed, err := time.ParseDuration(ageThreshold)
+	ageThresholdRaw, ok := c.GetQuery("age_threshold")
+	if !ok {
+		return defaultOrphanAgeThreshold, defaultOrphanAgeThresholdQuery, true
+	}
+
+	parsed, err := time.ParseDuration(ageThresholdRaw)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{
 			"error": "invalid age_threshold format",
 		})
-		return 0, ageThreshold, false
+		return 0, ageThresholdRaw, false
 	}
-	return parsed, ageThreshold, true
+	if parsed <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "age_threshold must be greater than 0",
+		})
+		return 0, ageThresholdRaw, false
+	}
+	return parsed, ageThresholdRaw, true
 }
 
 func (s *Server) runOrphanDetection(ctx context.Context, namespace string, ageThreshold time.Duration) (*orphan.DetectionResult, error) {
-	detector, err := orphan.NewDetector(s.k8sClient, s.truenasClient, orphan.Config{
-		AgeThreshold:      ageThreshold,
-		SnapshotRetention: s.orphanSnapshotRetention,
-		DryRun:            true,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create orphan detector: %w", err)
-	}
+	return s.orphanDetector.WithAgeThreshold(ageThreshold).DetectOrphanedResources(ctx, namespace)
+}
 
-	return detector.DetectOrphanedResources(ctx, namespace)
+func (s *Server) runOrphanPVDetection(ctx context.Context, ageThreshold time.Duration) (*orphan.DetectionResult, error) {
+	return s.orphanDetector.WithAgeThreshold(ageThreshold).DetectOrphanedPVs(ctx)
 }
 
 func notImplemented(c *gin.Context, endpoint string) {
@@ -250,12 +279,12 @@ func (s *Server) listOrphansHandler(c *gin.Context) {
 
 // listOrphanedPVsHandler handles requests for orphaned PVs
 func (s *Server) listOrphanedPVsHandler(c *gin.Context) {
-	ageThreshold, _, ok := s.parseAgeThreshold(c)
+	ageThreshold, ageThresholdRaw, ok := s.parseAgeThreshold(c)
 	if !ok {
 		return
 	}
 
-	result, err := s.runOrphanDetection(c.Request.Context(), "", ageThreshold)
+	result, err := s.runOrphanPVDetection(c.Request.Context(), ageThreshold)
 	if err != nil {
 		s.logger.Error("Failed to detect orphaned PVs", zap.Error(err))
 		c.JSON(http.StatusInternalServerError, gin.H{
@@ -266,6 +295,7 @@ func (s *Server) listOrphanedPVsHandler(c *gin.Context) {
 
 	c.JSON(http.StatusOK, gin.H{
 		"timestamp":     result.Timestamp,
+		"age_threshold": ageThresholdRaw,
 		"total_pvs":     result.TotalPVs,
 		"orphaned_pvs":  result.OrphanedPVs,
 		"total_orphans": len(result.OrphanedPVs),
@@ -473,9 +503,14 @@ func rateLimitMiddleware() gin.HandlerFunc {
 
 	return func(c *gin.Context) {
 		if !limiter.Allow() {
+			retryAfter := time.Second
+			if reservation := limiter.Reserve(); reservation.OK() {
+				retryAfter = reservation.Delay()
+				reservation.Cancel()
+			}
 			c.JSON(http.StatusTooManyRequests, gin.H{
 				"error":       "rate limit exceeded",
-				"retry_after": "60s",
+				"retry_after": retryAfter.String(),
 			})
 			c.Abort()
 			return

--- a/go/pkg/api/server.go
+++ b/go/pkg/api/server.go
@@ -9,20 +9,21 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/k8s"
-	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/logging"
-	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/monitor"
+	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/orphan"
 	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/truenas"
 	"go.uber.org/zap"
 	"golang.org/x/time/rate"
 )
 
+const defaultOrphanAgeThreshold = 24 * time.Hour
+
 // Server represents the API server
 type Server struct {
-	server         *http.Server
-	k8sClient      k8s.Client
-	truenasClient  truenas.Client
-	logger         *zap.Logger
-	monitorService *monitor.Service
+	server                  *http.Server
+	k8sClient               k8s.Client
+	truenasClient           truenas.Client
+	logger                  *zap.Logger
+	orphanSnapshotRetention time.Duration
 }
 
 // Config holds the server configuration
@@ -40,39 +41,27 @@ func NewServer(config Config) (*Server, error) {
 
 	// Create router
 	router := gin.New()
-	
+
 	// Add recovery middleware
 	router.Use(gin.Recovery())
-	
+
 	// Add CORS middleware
 	router.Use(corsMiddleware())
-	
+
 	// Add request ID middleware for tracing
 	router.Use(requestIDMiddleware())
-	
+
 	// Add logging middleware
 	router.Use(loggingMiddleware(config.Logger))
-	
+
 	// Add rate limiting middleware
 	router.Use(rateLimitMiddleware())
 
-	// Initialize monitor service for the API server
-	monitorService, err := monitor.NewService(monitor.Config{
-		K8sClient:       config.K8sClient,
-		TruenasClient:   config.TruenasClient,
-		MetricsExporter: nil, // API server doesn't need metrics exporter
-		Logger:          &logging.Logger{Logger: config.Logger},
-		ScanInterval:    5 * time.Minute,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create monitor service: %w", err)
-	}
-
 	server := &Server{
-		k8sClient:      config.K8sClient,
-		truenasClient:  config.TruenasClient,
-		logger:         config.Logger,
-		monitorService: monitorService,
+		k8sClient:               config.K8sClient,
+		truenasClient:           config.TruenasClient,
+		logger:                  config.Logger,
+		orphanSnapshotRetention: 30 * 24 * time.Hour,
 	}
 
 	// Setup routes
@@ -80,11 +69,11 @@ func NewServer(config Config) (*Server, error) {
 
 	// Create HTTP server with enhanced configuration
 	server.server = &http.Server{
-		Addr:         fmt.Sprintf(":%d", config.Port),
-		Handler:      router,
-		ReadTimeout:  30 * time.Second,
-		WriteTimeout: 30 * time.Second,
-		IdleTimeout:  120 * time.Second,
+		Addr:           fmt.Sprintf(":%d", config.Port),
+		Handler:        router,
+		ReadTimeout:    30 * time.Second,
+		WriteTimeout:   30 * time.Second,
+		IdleTimeout:    120 * time.Second,
 		MaxHeaderBytes: 1 << 20, // 1MB
 	}
 
@@ -153,6 +142,39 @@ func (s *Server) setupRoutes(router *gin.Engine) {
 	}
 }
 
+func (s *Server) parseAgeThreshold(c *gin.Context) (time.Duration, string, bool) {
+	ageThreshold := c.DefaultQuery("age_threshold", defaultOrphanAgeThreshold.String())
+	parsed, err := time.ParseDuration(ageThreshold)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "invalid age_threshold format",
+		})
+		return 0, ageThreshold, false
+	}
+	return parsed, ageThreshold, true
+}
+
+func (s *Server) runOrphanDetection(ctx context.Context, namespace string, ageThreshold time.Duration) (*orphan.DetectionResult, error) {
+	detector, err := orphan.NewDetector(s.k8sClient, s.truenasClient, orphan.Config{
+		AgeThreshold:      ageThreshold,
+		SnapshotRetention: s.orphanSnapshotRetention,
+		DryRun:            true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create orphan detector: %w", err)
+	}
+
+	return detector.DetectOrphanedResources(ctx, namespace)
+}
+
+func notImplemented(c *gin.Context, endpoint string) {
+	c.JSON(http.StatusNotImplemented, gin.H{
+		"error":    "not_implemented",
+		"message":  "endpoint not implemented",
+		"endpoint": endpoint,
+	})
+}
+
 // healthHandler handles health check requests
 func (s *Server) healthHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{
@@ -194,56 +216,60 @@ func (s *Server) readyHandler(c *gin.Context) {
 
 // listOrphansHandler handles requests for all orphaned resources
 func (s *Server) listOrphansHandler(c *gin.Context) {
-	// Get query parameters
 	namespace := c.Query("namespace")
-	ageThreshold := c.DefaultQuery("age_threshold", "24h")
+	ageThreshold, ageThresholdRaw, ok := s.parseAgeThreshold(c)
+	if !ok {
+		return
+	}
 
-	// Parse age threshold
-	_, err := time.ParseDuration(ageThreshold)
+	result, err := s.runOrphanDetection(c.Request.Context(), namespace, ageThreshold)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error": "invalid age_threshold format",
+		s.logger.Error("Failed to detect orphaned resources", zap.Error(err))
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "orphan detection failed",
 		})
 		return
 	}
 
-	// TODO: Implement orphan detection logic
-	// This is a placeholder response
-	result := gin.H{
-		"timestamp":          time.Now().UTC(),
-		"namespace":          namespace,
-		"age_threshold":      ageThreshold,
-		"orphaned_pvs":       []interface{}{},
-		"orphaned_pvcs":      []interface{}{},
-		"orphaned_snapshots": []interface{}{},
-		"total_orphans":      0,
-	}
+	totalOrphans := len(result.OrphanedPVs) + len(result.OrphanedPVCs) + len(result.OrphanedSnapshots)
 
-	c.JSON(http.StatusOK, result)
+	c.JSON(http.StatusOK, gin.H{
+		"timestamp":          result.Timestamp,
+		"namespace":          namespace,
+		"age_threshold":      ageThresholdRaw,
+		"orphaned_pvs":       result.OrphanedPVs,
+		"orphaned_pvcs":      result.OrphanedPVCs,
+		"orphaned_snapshots": result.OrphanedSnapshots,
+		"total_pvs":          result.TotalPVs,
+		"total_pvcs":         result.TotalPVCs,
+		"total_snapshots":    result.TotalSnapshots,
+		"scan_duration":      result.ScanDuration.String(),
+		"total_orphans":      totalOrphans,
+	})
 }
 
 // listOrphanedPVsHandler handles requests for orphaned PVs
 func (s *Server) listOrphanedPVsHandler(c *gin.Context) {
-	ctx := c.Request.Context()
+	ageThreshold, _, ok := s.parseAgeThreshold(c)
+	if !ok {
+		return
+	}
 
-	pvs, err := s.k8sClient.ListPersistentVolumes(ctx)
+	result, err := s.runOrphanDetection(c.Request.Context(), "", ageThreshold)
 	if err != nil {
-		s.logger.Error("Failed to list PVs", zap.Error(err))
+		s.logger.Error("Failed to detect orphaned PVs", zap.Error(err))
 		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": "failed to list persistent volumes",
+			"error": "orphan detection failed",
 		})
 		return
 	}
 
-	// TODO: Implement orphan detection logic
-	result := gin.H{
-		"timestamp":     time.Now().UTC(),
-		"total_pvs":     len(pvs),
-		"orphaned_pvs":  []interface{}{},
-		"total_orphans": 0,
-	}
-
-	c.JSON(http.StatusOK, result)
+	c.JSON(http.StatusOK, gin.H{
+		"timestamp":     result.Timestamp,
+		"total_pvs":     result.TotalPVs,
+		"orphaned_pvs":  result.OrphanedPVs,
+		"total_orphans": len(result.OrphanedPVs),
+	})
 }
 
 // listPVsHandler handles requests for all PVs
@@ -337,22 +363,65 @@ func (s *Server) validateHandler(c *gin.Context) {
 	})
 }
 
-// Placeholder handlers for other endpoints
-func (s *Server) listOrphanedPVCsHandler(c *gin.Context)      { c.JSON(http.StatusNotImplemented, gin.H{"message": "not implemented"}) }
-func (s *Server) listOrphanedSnapshotsHandler(c *gin.Context) { c.JSON(http.StatusNotImplemented, gin.H{"message": "not implemented"}) }
-func (s *Server) storageAnalysisHandler(c *gin.Context)       { c.JSON(http.StatusNotImplemented, gin.H{"message": "not implemented"}) }
-func (s *Server) storageUsageHandler(c *gin.Context)          { c.JSON(http.StatusNotImplemented, gin.H{"message": "not implemented"}) }
-func (s *Server) storageTrendsHandler(c *gin.Context)         { c.JSON(http.StatusNotImplemented, gin.H{"message": "not implemented"}) }
-func (s *Server) listPVCsHandler(c *gin.Context)              { c.JSON(http.StatusNotImplemented, gin.H{"message": "not implemented"}) }
-func (s *Server) listSnapshotsHandler(c *gin.Context)         { c.JSON(http.StatusNotImplemented, gin.H{"message": "not implemented"}) }
-func (s *Server) listStorageClassesHandler(c *gin.Context)    { c.JSON(http.StatusNotImplemented, gin.H{"message": "not implemented"}) }
-func (s *Server) listTrueNASSnapshotsHandler(c *gin.Context)  { c.JSON(http.StatusNotImplemented, gin.H{"message": "not implemented"}) }
-func (s *Server) listTrueNASPoolsHandler(c *gin.Context)      { c.JSON(http.StatusNotImplemented, gin.H{"message": "not implemented"}) }
-func (s *Server) getTrueNASInfoHandler(c *gin.Context)        { c.JSON(http.StatusNotImplemented, gin.H{"message": "not implemented"}) }
-func (s *Server) validateConfigHandler(c *gin.Context)        { c.JSON(http.StatusNotImplemented, gin.H{"message": "not implemented"}) }
-func (s *Server) validateConnectivityHandler(c *gin.Context)  { c.JSON(http.StatusNotImplemented, gin.H{"message": "not implemented"}) }
-func (s *Server) summaryReportHandler(c *gin.Context)         { c.JSON(http.StatusNotImplemented, gin.H{"message": "not implemented"}) }
-func (s *Server) detailedReportHandler(c *gin.Context)        { c.JSON(http.StatusNotImplemented, gin.H{"message": "not implemented"}) }
+func (s *Server) listOrphanedPVCsHandler(c *gin.Context) {
+	notImplemented(c, "/api/v1/orphans/pvcs")
+}
+
+func (s *Server) listOrphanedSnapshotsHandler(c *gin.Context) {
+	notImplemented(c, "/api/v1/orphans/snapshots")
+}
+
+func (s *Server) storageAnalysisHandler(c *gin.Context) {
+	notImplemented(c, "/api/v1/analysis")
+}
+
+func (s *Server) storageUsageHandler(c *gin.Context) {
+	notImplemented(c, "/api/v1/analysis/usage")
+}
+
+func (s *Server) storageTrendsHandler(c *gin.Context) {
+	notImplemented(c, "/api/v1/analysis/trends")
+}
+
+func (s *Server) listPVCsHandler(c *gin.Context) {
+	notImplemented(c, "/api/v1/resources/pvcs")
+}
+
+func (s *Server) listSnapshotsHandler(c *gin.Context) {
+	notImplemented(c, "/api/v1/resources/snapshots")
+}
+
+func (s *Server) listStorageClassesHandler(c *gin.Context) {
+	notImplemented(c, "/api/v1/resources/storageclasses")
+}
+
+func (s *Server) listTrueNASSnapshotsHandler(c *gin.Context) {
+	notImplemented(c, "/api/v1/truenas/snapshots")
+}
+
+func (s *Server) listTrueNASPoolsHandler(c *gin.Context) {
+	notImplemented(c, "/api/v1/truenas/pools")
+}
+
+func (s *Server) getTrueNASInfoHandler(c *gin.Context) {
+	notImplemented(c, "/api/v1/truenas/info")
+}
+
+func (s *Server) validateConfigHandler(c *gin.Context) {
+	notImplemented(c, "/api/v1/validate/config")
+}
+
+func (s *Server) validateConnectivityHandler(c *gin.Context) {
+	notImplemented(c, "/api/v1/validate/connectivity")
+}
+
+func (s *Server) summaryReportHandler(c *gin.Context) {
+	notImplemented(c, "/api/v1/reports/summary")
+}
+
+func (s *Server) detailedReportHandler(c *gin.Context) {
+	notImplemented(c, "/api/v1/reports/detailed")
+}
 
 // corsMiddleware adds CORS headers
 func corsMiddleware() gin.HandlerFunc {
@@ -401,11 +470,11 @@ func requestIDMiddleware() gin.HandlerFunc {
 func rateLimitMiddleware() gin.HandlerFunc {
 	// Create a rate limiter: 100 requests per minute
 	limiter := rate.NewLimiter(rate.Every(time.Minute/100), 100)
-	
+
 	return func(c *gin.Context) {
 		if !limiter.Allow() {
 			c.JSON(http.StatusTooManyRequests, gin.H{
-				"error": "rate limit exceeded",
+				"error":       "rate limit exceeded",
 				"retry_after": "60s",
 			})
 			c.Abort()

--- a/go/pkg/api/server_test.go
+++ b/go/pkg/api/server_test.go
@@ -225,6 +225,31 @@ func TestListOrphansHandler_InvalidAgeThreshold_Returns400(t *testing.T) {
 	require.Equal(t, "invalid age_threshold format", body["error"])
 }
 
+func TestListOrphansHandler_NonPositiveAgeThreshold_Returns400(t *testing.T) {
+	server := newTestServer(t, &stubK8sClient{}, &stubTruenasClient{})
+
+	rec := performRequest(server, http.MethodGet, "/api/v1/orphans?age_threshold=0")
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Equal(t, "age_threshold must be greater than 0", body["error"])
+}
+
+func TestListOrphansHandler_DefaultAgeThresholdEchoes24h(t *testing.T) {
+	k8sStub := &stubK8sClient{
+		democraticPVs: []corev1.PersistentVolume{orphanedDemocraticPV("orphan-pv")},
+	}
+	server := newTestServer(t, k8sStub, &stubTruenasClient{})
+
+	rec := performRequest(server, http.MethodGet, "/api/v1/orphans")
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Equal(t, "24h", body["age_threshold"])
+}
+
 func TestListOrphanedPVsHandler_ReturnsPVSubsetOnly(t *testing.T) {
 	k8sStub := &stubK8sClient{
 		democraticPVs: []corev1.PersistentVolume{orphanedDemocraticPV("orphan-pv")},

--- a/go/pkg/api/server_test.go
+++ b/go/pkg/api/server_test.go
@@ -1,0 +1,299 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
+	"github.com/stretchr/testify/require"
+	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/k8s"
+	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/truenas"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"go.uber.org/zap"
+)
+
+type stubK8sClient struct {
+	democraticPVs      []corev1.PersistentVolume
+	democraticPVsErr   error
+	unboundPVCs        []corev1.PersistentVolumeClaim
+	allPVCs            []corev1.PersistentVolumeClaim
+	volumeSnapshots    []snapshotv1.VolumeSnapshot
+	listPersistentPVs  []corev1.PersistentVolume
+	testConnectionErr  error
+}
+
+func (s *stubK8sClient) ListPersistentVolumes(context.Context) ([]corev1.PersistentVolume, error) {
+	return s.listPersistentPVs, nil
+}
+
+func (s *stubK8sClient) ListPersistentVolumeClaims(context.Context, string) ([]corev1.PersistentVolumeClaim, error) {
+	if s.allPVCs == nil {
+		return []corev1.PersistentVolumeClaim{}, nil
+	}
+	return s.allPVCs, nil
+}
+
+func (s *stubK8sClient) ListVolumeSnapshots(context.Context, string) ([]snapshotv1.VolumeSnapshot, error) {
+	if s.volumeSnapshots == nil {
+		return []snapshotv1.VolumeSnapshot{}, nil
+	}
+	return s.volumeSnapshots, nil
+}
+
+func (s *stubK8sClient) ListStorageClasses(context.Context) ([]storagev1.StorageClass, error) {
+	return nil, nil
+}
+
+func (s *stubK8sClient) ListPods(context.Context, string) ([]corev1.Pod, error) {
+	return nil, nil
+}
+
+func (s *stubK8sClient) ListNamespaces(context.Context) ([]corev1.Namespace, error) {
+	return nil, nil
+}
+
+func (s *stubK8sClient) GetNamespace(context.Context, string) (*corev1.Namespace, error) {
+	return nil, nil
+}
+
+func (s *stubK8sClient) ListPersistentVolumesByStorageClass(context.Context, string) ([]corev1.PersistentVolume, error) {
+	return nil, nil
+}
+
+func (s *stubK8sClient) ListPersistentVolumeClaimsByStorageClass(context.Context, string, string) ([]corev1.PersistentVolumeClaim, error) {
+	return nil, nil
+}
+
+func (s *stubK8sClient) ListDemocraticCSIPersistentVolumes(context.Context) ([]corev1.PersistentVolume, error) {
+	if s.democraticPVsErr != nil {
+		return nil, s.democraticPVsErr
+	}
+	if s.democraticPVs == nil {
+		return []corev1.PersistentVolume{}, nil
+	}
+	return s.democraticPVs, nil
+}
+
+func (s *stubK8sClient) ListUnboundPersistentVolumeClaims(context.Context, string) ([]corev1.PersistentVolumeClaim, error) {
+	if s.unboundPVCs == nil {
+		return []corev1.PersistentVolumeClaim{}, nil
+	}
+	return s.unboundPVCs, nil
+}
+
+func (s *stubK8sClient) TestConnection(context.Context) error {
+	return s.testConnectionErr
+}
+
+func (s *stubK8sClient) ValidateRBACPermissions(context.Context) (*k8s.RBACValidationResult, error) {
+	return nil, nil
+}
+
+func (s *stubK8sClient) GetClusterInfo(context.Context) (*k8s.ClusterInfo, error) {
+	return nil, nil
+}
+
+func (s *stubK8sClient) ListCSINodes(context.Context) ([]storagev1.CSINode, error) {
+	return nil, nil
+}
+
+func (s *stubK8sClient) ListCSIDrivers(context.Context) ([]storagev1.CSIDriver, error) {
+	return nil, nil
+}
+
+func (s *stubK8sClient) ListVolumeAttachments(context.Context) ([]storagev1.VolumeAttachment, error) {
+	return nil, nil
+}
+
+func (s *stubK8sClient) GetCSIDriverPods(context.Context, string) ([]corev1.Pod, error) {
+	return nil, nil
+}
+
+type stubTruenasClient struct {
+	volumes           []truenas.Volume
+	snapshots         []truenas.Snapshot
+	testConnectionErr error
+	listVolumesErr    error
+}
+
+func (s *stubTruenasClient) ListVolumes(context.Context) ([]truenas.Volume, error) {
+	if s.listVolumesErr != nil {
+		return nil, s.listVolumesErr
+	}
+	if s.volumes == nil {
+		return []truenas.Volume{}, nil
+	}
+	return s.volumes, nil
+}
+
+func (s *stubTruenasClient) ListSnapshots(context.Context) ([]truenas.Snapshot, error) {
+	if s.snapshots == nil {
+		return []truenas.Snapshot{}, nil
+	}
+	return s.snapshots, nil
+}
+
+func (s *stubTruenasClient) ListPools(context.Context) ([]truenas.Pool, error) {
+	return nil, nil
+}
+
+func (s *stubTruenasClient) GetSystemInfo(context.Context) (*truenas.SystemInfo, error) {
+	return nil, nil
+}
+
+func (s *stubTruenasClient) TestConnection(context.Context) error {
+	return s.testConnectionErr
+}
+
+func newTestServer(t *testing.T, k8sClient k8s.Client, truenasClient truenas.Client) *Server {
+	t.Helper()
+
+	gin.SetMode(gin.TestMode)
+	logger := zap.NewNop()
+
+	server, err := NewServer(Config{
+		Port:          0,
+		K8sClient:     k8sClient,
+		TruenasClient: truenasClient,
+		Logger:        logger,
+	})
+	require.NoError(t, err)
+
+	return server
+}
+
+func performRequest(server *Server, method, path string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(method, path, nil)
+	rec := httptest.NewRecorder()
+	server.server.Handler.ServeHTTP(rec, req)
+	return rec
+}
+
+func orphanedDemocraticPV(name string) corev1.PersistentVolume {
+	return corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-48 * time.Hour)),
+		},
+		Spec: corev1.PersistentVolumeSpec{
+			StorageClassName: "democratic-csi-nfs",
+			PersistentVolumeSource: corev1.PersistentVolumeSource{
+				CSI: &corev1.CSIPersistentVolumeSource{
+					Driver:       "org.democratic-csi.nfs",
+					VolumeHandle: "tank/k8s/" + name,
+				},
+			},
+		},
+	}
+}
+
+func TestListOrphansHandler_ReturnsDetectorResults(t *testing.T) {
+	k8sStub := &stubK8sClient{
+		democraticPVs: []corev1.PersistentVolume{orphanedDemocraticPV("orphan-pv")},
+	}
+	truenasStub := &stubTruenasClient{volumes: []truenas.Volume{}}
+	server := newTestServer(t, k8sStub, truenasStub)
+
+	rec := performRequest(server, http.MethodGet, "/api/v1/orphans?age_threshold=24h")
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+
+	orphanedPVs, ok := body["orphaned_pvs"].([]interface{})
+	require.True(t, ok)
+	require.NotEmpty(t, orphanedPVs)
+	require.EqualValues(t, 1, body["total_orphans"])
+}
+
+func TestListOrphansHandler_InvalidAgeThreshold_Returns400(t *testing.T) {
+	server := newTestServer(t, &stubK8sClient{}, &stubTruenasClient{})
+
+	rec := performRequest(server, http.MethodGet, "/api/v1/orphans?age_threshold=not-a-duration")
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Equal(t, "invalid age_threshold format", body["error"])
+}
+
+func TestListOrphanedPVsHandler_ReturnsPVSubsetOnly(t *testing.T) {
+	k8sStub := &stubK8sClient{
+		democraticPVs: []corev1.PersistentVolume{orphanedDemocraticPV("orphan-pv")},
+	}
+	truenasStub := &stubTruenasClient{volumes: []truenas.Volume{}}
+	server := newTestServer(t, k8sStub, truenasStub)
+
+	rec := performRequest(server, http.MethodGet, "/api/v1/orphans/pvs?age_threshold=24h")
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+
+	orphanedPVs, ok := body["orphaned_pvs"].([]interface{})
+	require.True(t, ok)
+	require.NotEmpty(t, orphanedPVs)
+	require.EqualValues(t, 1, body["total_orphans"])
+	require.NotContains(t, body, "orphaned_pvcs")
+	require.NotContains(t, body, "orphaned_snapshots")
+}
+
+func TestListOrphansHandler_DetectorError_Returns500(t *testing.T) {
+	k8sStub := &stubK8sClient{
+		democraticPVsErr: errors.New("kubernetes unavailable"),
+	}
+	server := newTestServer(t, k8sStub, &stubTruenasClient{})
+
+	rec := performRequest(server, http.MethodGet, "/api/v1/orphans")
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Equal(t, "orphan detection failed", body["error"])
+}
+
+func TestNotImplementedRoutes_Return501WithStandardEnvelope(t *testing.T) {
+	server := newTestServer(t, &stubK8sClient{}, &stubTruenasClient{})
+
+	routes := []struct {
+		path     string
+		endpoint string
+	}{
+		{"/api/v1/orphans/pvcs", "/api/v1/orphans/pvcs"},
+		{"/api/v1/orphans/snapshots", "/api/v1/orphans/snapshots"},
+		{"/api/v1/analysis", "/api/v1/analysis"},
+		{"/api/v1/analysis/usage", "/api/v1/analysis/usage"},
+		{"/api/v1/analysis/trends", "/api/v1/analysis/trends"},
+		{"/api/v1/resources/pvcs", "/api/v1/resources/pvcs"},
+		{"/api/v1/resources/snapshots", "/api/v1/resources/snapshots"},
+		{"/api/v1/resources/storageclasses", "/api/v1/resources/storageclasses"},
+		{"/api/v1/truenas/snapshots", "/api/v1/truenas/snapshots"},
+		{"/api/v1/truenas/pools", "/api/v1/truenas/pools"},
+		{"/api/v1/truenas/info", "/api/v1/truenas/info"},
+		{"/api/v1/validate/config", "/api/v1/validate/config"},
+		{"/api/v1/validate/connectivity", "/api/v1/validate/connectivity"},
+		{"/api/v1/reports/summary", "/api/v1/reports/summary"},
+		{"/api/v1/reports/detailed", "/api/v1/reports/detailed"},
+	}
+
+	for _, route := range routes {
+		t.Run(route.path, func(t *testing.T) {
+			rec := performRequest(server, http.MethodGet, route.path)
+			require.Equal(t, http.StatusNotImplemented, rec.Code)
+
+			var body map[string]interface{}
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+			require.Equal(t, "not_implemented", body["error"])
+			require.Equal(t, "endpoint not implemented", body["message"])
+			require.Equal(t, route.endpoint, body["endpoint"])
+		})
+	}
+}

--- a/go/pkg/orphan/detector.go
+++ b/go/pkg/orphan/detector.go
@@ -137,6 +137,46 @@ func (d *Detector) DetectOrphanedResources(ctx context.Context, namespace string
 	return result, nil
 }
 
+// WithAgeThreshold returns a detector copy that reuses clients and logger.
+func (d *Detector) WithAgeThreshold(ageThreshold time.Duration) *Detector {
+	return &Detector{
+		k8sClient:     d.k8sClient,
+		truenasClient: d.truenasClient,
+		logger:        d.logger,
+		config: Config{
+			AgeThreshold:      ageThreshold,
+			SnapshotRetention: d.config.SnapshotRetention,
+			DryRun:            d.config.DryRun,
+		},
+	}
+}
+
+// DetectOrphanedPVs performs PV-only orphan detection.
+func (d *Detector) DetectOrphanedPVs(ctx context.Context) (*DetectionResult, error) {
+	start := time.Now()
+
+	orphanedPVs, totalPVs, err := d.detectOrphanedPVs(ctx)
+	if err != nil {
+		d.logger.WithError(err).Error("Failed to detect orphaned PVs")
+		return nil, fmt.Errorf("failed to detect orphaned PVs: %w", err)
+	}
+
+	result := &DetectionResult{
+		Timestamp:   start,
+		OrphanedPVs: orphanedPVs,
+		TotalPVs:    totalPVs,
+		ScanDuration: time.Since(start),
+	}
+
+	d.logger.Info("PV orphan detection completed",
+		zap.Int("total_pvs", result.TotalPVs),
+		zap.Int("orphaned_pvs", len(result.OrphanedPVs)),
+		zap.String("age_threshold", d.config.AgeThreshold.String()),
+	)
+
+	return result, nil
+}
+
 // detectOrphanedPVs identifies PVs without corresponding TrueNAS volumes
 func (d *Detector) detectOrphanedPVs(ctx context.Context) ([]OrphanedResource, int, error) {
 	// Get all democratic-csi PVs from Kubernetes


### PR DESCRIPTION
## Summary

- Wire `/api/v1/orphans` and `/api/v1/orphans/pvs` to `orphan.Detector` instead of returning misleading empty success payloads
- Remove unused `monitor.Service` wiring from the API server
- Standardize HTTP 501 JSON envelope for unimplemented routes and add handler contract tests
- Add API endpoint maturity doc and PR-4 design spec

**Design spec:** [docs/superpowers/specs/2026-05-28-pr-4-api-honesty-design.md](docs/superpowers/specs/2026-05-28-pr-4-api-honesty-design.md)

## Test plan

- [x] `cd go && go test ./pkg/api/... -v -cover`
- [x] `cd go && go test ./... -v`
- [x] `cd go && go vet ./...`
- [x] `make go-lint`

## PR checklist

- [x] **Scope:** Maps to remediation plan PR 4 (API honesty)
- [x] **Correctness:** Added handler tests for orphan routes, 501 envelope, and error paths
- [x] **Regression Safety:** Full Go test suite passes
- [x] **Security:** Read-only orphan detection (`DryRun: true`); no new secrets or insecure defaults
- [x] **Reliability:** Detector failures return HTTP 500 with explicit error
- [x] **Performance:** Synchronous per-request detection documented in `docs/api-endpoints.md`
- [x] **Docs:** Added `docs/api-endpoints.md` and README link
- [x] **Ops/Runbook:** Spec includes rollout/backout notes for orphan endpoint behavior change
- [x] **Verification Evidence:** See test plan above
- [x] **Tracking:** Remediation plan PR 4 marked In Progress with acceptance criteria checked

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Orphan endpoints now run real detection with a configurable age_threshold (validated, with a 24h default).

* **Bug Fixes / Improvements**
  * Consistent 501 "not implemented" JSON responses and dynamic rate-limit retry_after values.
  * Orphan PV endpoint returns PV-only results.

* **Tests**
  * Expanded server tests covering age_threshold validation, defaults, detection failures, and unimplemented routes.

* **Documentation**
  * Added API endpoint maturity doc, new API design/spec, updated roadmap/plans, and README link updated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tomazb/kubernetes-truenas-democratic-tool/pull/54?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->