### PR TITLE
fix(detector): orphan snapshot correlation and RBAC validation (PR 5)

### DIFF
--- a/docs/superpowers/plans/2026-05-28-repo-health-remediation.md
+++ b/docs/superpowers/plans/2026-05-28-repo-health-remediation.md
@@ -263,7 +263,7 @@ Suggested worktree layout:
 
 ### PR 5: Orphan Detection and Validation Debt
 
-- **Status:** Planned
+- **Status:** In Progress
 - **Risk:** High
 - **Focus:** Replace hardcoded detector logic and optimistic validation stubs.
 - **Branch/worktree:**
@@ -276,14 +276,14 @@ Suggested worktree layout:
   - `go/pkg/orphan/*_test.go`
   - `go/pkg/k8s/*_test.go`
 - **Implementation steps:**
-  - [ ] Implement real snapshot matching in detector.
-  - [ ] Replace hardcoded `return true` paths with deterministic matching.
-  - [ ] Replace always-pass RBAC validation placeholders with real checks or explicit not-implemented errors.
-  - [ ] Add table-driven tests for volume handles and snapshot correlation.
+  - [x] Implement real snapshot matching in detector.
+  - [x] Replace hardcoded `return true` paths with deterministic matching.
+  - [x] Replace always-pass RBAC validation placeholders with real checks or explicit not-implemented errors.
+  - [x] Add table-driven tests for volume handles and snapshot correlation.
 - **Acceptance criteria:**
-  - [ ] Snapshot orphan detection produces real signal.
-  - [ ] Validation behavior is not silently optimistic.
-  - [ ] Tests cover core matching edge cases.
+  - [x] Snapshot orphan detection produces real signal.
+  - [x] Validation behavior is not silently optimistic.
+  - [x] Tests cover core matching edge cases.
 - **PR URL:** TBD
 
 ### PR 6: Reliability and Performance Guardrails

--- a/docs/superpowers/plans/2026-05-28-repo-health-remediation.md
+++ b/docs/superpowers/plans/2026-05-28-repo-health-remediation.md
@@ -284,7 +284,7 @@ Suggested worktree layout:
   - [x] Snapshot orphan detection produces real signal.
   - [x] Validation behavior is not silently optimistic.
   - [x] Tests cover core matching edge cases.
-- **PR URL:** TBD
+- **PR URL:** https://github.com/tomazb/kubernetes-truenas-democratic-tool/pull/55
 
 ### PR 6: Reliability and Performance Guardrails
 

--- a/docs/superpowers/specs/2026-05-28-pr-5-detector-validation-design.md
+++ b/docs/superpowers/specs/2026-05-28-pr-5-detector-validation-design.md
@@ -1,0 +1,112 @@
+# PR 5: Orphan Detection and Validation Debt — Design Spec
+
+**Date:** 2026-05-28  
+**Plan item:** [Remediation plan PR 5](../plans/2026-05-28-repo-health-remediation.md)  
+**Milestone:** M2 — Contract Integrity
+
+## Problem statement and scope
+
+PR 4 wired orphan API routes to `orphan.Detector`, but several detector and k8s client paths still return optimistic success:
+
+- Snapshot correlation helpers (`hasCorrespondingTrueNASSnapshot`, `hasCorrespondingK8sSnapshot`) always return `true`, so snapshot orphan detection never reports orphans.
+- `ValidateRBACPermissions` returns `HasRequiredPermissions: true` without checking the API server.
+- Volume-handle matching uses broad substring checks that can false-positive; tests do not cover edge cases.
+
+Operators relying on `/api/v1/orphans` after PR 4 get real PV/PVC signal but misleading snapshot and validation semantics.
+
+**In scope:**
+
+- Implement deterministic K8s ↔ TrueNAS snapshot matching using `snapshotv1.VolumeSnapshot` and `truenas.Snapshot`
+- Tighten volume-handle matching where low-risk (document remaining heuristics)
+- Replace optimistic `ValidateRBACPermissions` with SelfSubjectAccessReview-based checks for required list/get verbs, or return an explicit error (never silent `true`)
+- Add table-driven unit tests in `go/pkg/orphan/*_test.go` and `go/pkg/k8s/*_test.go`
+- Update remediation plan tracking
+
+**Out of scope:**
+
+- API route wiring / 501 envelope changes (PR 4, done)
+- Background monitor caching, rate limiter, retries (PR 6)
+- Full `GetClusterInfo` / CSI listing stubs (backlog unless required for RBAC UX)
+- Python CLI parity (later milestone)
+
+## Current behavior vs target behavior
+
+| Aspect | Current | Target |
+|--------|---------|--------|
+| K8s snapshot without TrueNAS peer | Never flagged (matcher returns `true`) | Flagged when age > threshold and no match |
+| TrueNAS snapshot without K8s peer | Never flagged (matcher returns `true`) | Flagged when older than retention and no match |
+| Snapshot matching | Stub `interface{}` params | Typed `VolumeSnapshot` / `[]truenas.Snapshot` |
+| `ValidateRBACPermissions` | Always `HasRequiredPermissions: true` | SSAR checks per required resource/verb; missing perms listed |
+| Volume handle matching | Broad `strings.Contains` on properties | Deterministic rules with table-driven tests |
+| Orphan package tests | None (`0%` coverage in CI) | Table-driven tests for matchers and snapshot paths |
+
+## Technical approach
+
+### 1. Snapshot correlation
+
+Match using democratic-csi conventions:
+
+- **K8s → TrueNAS:** Compare `VolumeSnapshot` name/namespace labels and `status.boundVolumeSnapshotContentName` / content source PVC to TrueNAS snapshot `Name`, `Dataset`, and `@` snapshot suffix patterns.
+- **TrueNAS → K8s:** Match `truenas.Snapshot.Dataset` + snapshot name to K8s snapshot metadata and volume snapshot content references.
+
+Extract small pure functions (e.g. `snapshotMatchesTrueNAS`, `snapshotMatchesK8s`) for testability.
+
+### 2. RBAC validation
+
+Use `authorizationv1.SelfSubjectAccessReview` for a minimal required set:
+
+- `persistentvolumes`: `list`, `get`
+- `persistentvolumeclaims`: `list`, `get`
+- `volumesnapshots.snapshot.storage.k8s.io`: `list`, `get` (when snapshot CRD client is configured)
+
+If snapshot client is nil/unavailable, record check as skipped with explicit message rather than `true`.
+
+### 3. Volume-handle matching
+
+Keep existing strategies but add tests for:
+
+- iSCSI `iqn.*:volume` handles
+- `pool/dataset/volume` paths
+- Non-match when dataset name is substring of unrelated volume
+- Empty handle / missing CSI
+
+Refine property `strings.Contains` only if tests prove false positives; otherwise document heuristic in code comment.
+
+### 4. Tests
+
+| Test file | Focus |
+|-----------|--------|
+| `go/pkg/orphan/detector_test.go` | Snapshot matchers, volume handle extraction, PV orphan age threshold |
+| `go/pkg/k8s/client_test.go` | `ValidateRBACPermissions` with fake clientset / SSAR responses |
+
+**Alternatives considered:**
+
+| Alternative | Decision |
+|-------------|----------|
+| Return 501 from monitor until snapshots fixed | Rejected — PR 5 scope is detector fidelity, not API removal |
+| Skip RBAC and document manual check | Rejected — violates API honesty; use real SSAR or explicit error |
+| Full VolumeSnapshotContent correlation | Deferred unless needed for match accuracy in tests |
+
+## Risk, failure modes, and mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| False-positive snapshot orphans due to naming drift | Table tests from documented handle formats; conservative matching |
+| SSAR requires in-cluster config | Unit tests with fake authorization interface; integration note in rollout |
+| Snapshot CRD not installed | Skip snapshot RBAC check with clear `PermissionChecks` entry |
+| Breaking change: non-zero snapshot orphans | Document in rollout; expected honesty fix |
+
+## Test strategy
+
+```bash
+cd go && go test ./pkg/orphan/... ./pkg/k8s/... -v -cover
+cd go && go test ./... -v
+cd go && go vet ./...
+make go-lint
+```
+
+## Rollout and backout
+
+**Rollout:** Deploy monitor/API builds. Snapshot orphan counts may increase from zero; RBAC validation may report missing permissions where previously always green.
+
+**Backout:** Revert PR; snapshot detection returns to no-op matchers and RBAC returns optimistic pass (not recommended).

--- a/go/pkg/k8s/client.go
+++ b/go/pkg/k8s/client.go
@@ -484,18 +484,6 @@ func (c *client) GetCSIDriverPods(ctx context.Context, namespace string) ([]core
 	return csiPods, nil
 }
 
-// Stub implementations for missing methods
-func (c *client) ValidateRBACPermissions(ctx context.Context) (*RBACValidationResult, error) {
-	// TODO: Implement RBAC validation
-	return &RBACValidationResult{
-		HasRequiredPermissions: true,
-		MissingPermissions:     []string{},
-		PermissionChecks:       map[string]bool{},
-		ServiceAccount:         "default",
-		Namespace:              "default",
-	}, nil
-}
-
 func (c *client) GetClusterInfo(ctx context.Context) (*ClusterInfo, error) {
 	// TODO: Implement cluster info gathering
 	return &ClusterInfo{

--- a/go/pkg/k8s/client_test.go
+++ b/go/pkg/k8s/client_test.go
@@ -230,6 +230,45 @@ func TestClient_ValidateRBACPermissions_Allowed(t *testing.T) {
 	if result.Namespace != "monitoring" {
 		t.Fatalf("namespace = %q, want monitoring", result.Namespace)
 	}
+	if !result.PermissionChecks["persistentvolumeclaims/list"] {
+		t.Fatal("expected namespaced PVC list check")
+	}
+}
+
+func TestClient_ValidateRBACPermissions_AllNamespacesScan(t *testing.T) {
+	ctx := context.Background()
+	fakeClient := fake.NewSimpleClientset()
+	fakeClient.PrependReactor(
+		"create",
+		"selfsubjectaccessreviews",
+		func(action k8stesting.Action) (bool, runtime.Object, error) {
+			review := action.(k8stesting.CreateAction).GetObject().(*authorizationv1.SelfSubjectAccessReview)
+			review.Status = authorizationv1.SubjectAccessReviewStatus{Allowed: true}
+			if review.Spec.ResourceAttributes != nil &&
+				review.Spec.ResourceAttributes.Namespace != "" &&
+				review.Spec.ResourceAttributes.Resource == "persistentvolumeclaims" {
+				t.Fatal("expected cluster-wide PVC SSAR without namespace when scan namespace is empty")
+			}
+			return true, review, nil
+		},
+	)
+
+	c := &client{
+		clientset: fakeClient,
+		config:    Config{Namespace: ""},
+		logger:    testLogger(t),
+	}
+
+	result, err := c.ValidateRBACPermissions(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Namespace != "" {
+		t.Fatalf("namespace = %q, want empty string for all-namespace scan mode", result.Namespace)
+	}
+	if !result.PermissionChecks["persistentvolumeclaims/list (all namespaces)"] {
+		t.Fatal("expected all-namespaces PVC list key")
+	}
 }
 
 func TestClient_ValidateRBACPermissions_Denied(t *testing.T) {

--- a/go/pkg/k8s/client_test.go
+++ b/go/pkg/k8s/client_test.go
@@ -6,11 +6,16 @@ import (
 	"path/filepath"
 	"testing"
 
+	authorizationv1 "k8s.io/api/authorization/v1"
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	snapshotfake "github.com/kubernetes-csi/external-snapshotter/client/v6/clientset/versioned/fake"
 
 	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/logging"
 )
@@ -190,4 +195,81 @@ func TestClient_ListStorageClasses(t *testing.T) {
 
 func stringPtr(s string) *string {
 	return &s
+}
+
+func TestClient_ValidateRBACPermissions_Allowed(t *testing.T) {
+	ctx := context.Background()
+	fakeClient := fake.NewSimpleClientset()
+	fakeClient.PrependReactor(
+		"create",
+		"selfsubjectaccessreviews",
+		func(action k8stesting.Action) (bool, runtime.Object, error) {
+			review := action.(k8stesting.CreateAction).GetObject().(*authorizationv1.SelfSubjectAccessReview)
+			review.Status = authorizationv1.SubjectAccessReviewStatus{Allowed: true}
+			return true, review, nil
+		},
+	)
+
+	c := &client{
+		clientset:      fakeClient,
+		snapshotClient: snapshotfake.NewSimpleClientset(),
+		config:         Config{Namespace: "monitoring"},
+		logger:         testLogger(t),
+	}
+
+	result, err := c.ValidateRBACPermissions(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.HasRequiredPermissions {
+		t.Fatalf("expected HasRequiredPermissions true, missing=%v", result.MissingPermissions)
+	}
+	if !result.PermissionChecks["persistentvolumes/list"] {
+		t.Fatal("expected persistentvolumes/list allowed")
+	}
+	if result.Namespace != "monitoring" {
+		t.Fatalf("namespace = %q, want monitoring", result.Namespace)
+	}
+}
+
+func TestClient_ValidateRBACPermissions_Denied(t *testing.T) {
+	ctx := context.Background()
+	fakeClient := fake.NewSimpleClientset()
+	fakeClient.PrependReactor(
+		"create",
+		"selfsubjectaccessreviews",
+		func(action k8stesting.Action) (bool, runtime.Object, error) {
+			review := action.(k8stesting.CreateAction).GetObject().(*authorizationv1.SelfSubjectAccessReview)
+			allowed := review.Spec.ResourceAttributes.Resource != "persistentvolumes"
+			review.Status = authorizationv1.SubjectAccessReviewStatus{Allowed: allowed}
+			return true, review, nil
+		},
+	)
+
+	c := &client{
+		clientset:      fakeClient,
+		snapshotClient: nil,
+		config:         Config{Namespace: "default"},
+		logger:         testLogger(t),
+	}
+
+	result, err := c.ValidateRBACPermissions(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.HasRequiredPermissions {
+		t.Fatal("expected HasRequiredPermissions false when PV list denied")
+	}
+	if len(result.MissingPermissions) == 0 {
+		t.Fatal("expected missing permissions listed")
+	}
+	foundSkip := false
+	for _, m := range result.MissingPermissions {
+		if m == "skipped: volumesnapshots (snapshot client unavailable)" {
+			foundSkip = true
+		}
+	}
+	if !foundSkip {
+		t.Fatalf("expected snapshot skip note, got %v", result.MissingPermissions)
+	}
 }

--- a/go/pkg/k8s/rbac.go
+++ b/go/pkg/k8s/rbac.go
@@ -9,45 +9,61 @@ import (
 )
 
 type rbacRequirement struct {
-	key             string
-	group           string
-	version         string
-	resource        string
-	verb            string
-	namespace       string
-	clusterScoped   bool
+	key           string
+	group         string
+	version       string
+	resource      string
+	verb          string
+	namespace     string
+	clusterScoped bool
 }
 
 func (c *client) ValidateRBACPermissions(ctx context.Context) (*RBACValidationResult, error) {
-	namespace := c.config.Namespace
-	if namespace == "" {
-		namespace = "default"
-	}
+	scanAllNamespaces := c.config.Namespace == ""
+	reportNamespace := c.config.Namespace
 
 	requirements := []rbacRequirement{
 		{key: "persistentvolumes/list", resource: "persistentvolumes", verb: "list", clusterScoped: true},
 		{key: "persistentvolumes/get", resource: "persistentvolumes", verb: "get", clusterScoped: true},
-		{key: "persistentvolumeclaims/list", resource: "persistentvolumeclaims", verb: "list", namespace: namespace},
-		{key: "persistentvolumeclaims/get", resource: "persistentvolumeclaims", verb: "get", namespace: namespace},
 	}
 
+	pvcNamespace := c.config.Namespace
+	pvcListKey := "persistentvolumeclaims/list"
+	pvcGetKey := "persistentvolumeclaims/get"
+	if scanAllNamespaces {
+		pvcListKey = "persistentvolumeclaims/list (all namespaces)"
+		pvcGetKey = "persistentvolumeclaims/get (all namespaces)"
+	}
+
+	requirements = append(requirements,
+		rbacRequirement{key: pvcListKey, resource: "persistentvolumeclaims", verb: "list", namespace: pvcNamespace},
+		rbacRequirement{key: pvcGetKey, resource: "persistentvolumeclaims", verb: "get", namespace: pvcNamespace},
+	)
+
 	if c.snapshotClient != nil {
+		snapNS := c.config.Namespace
+		snapListKey := "volumesnapshots.snapshot.storage.k8s.io/list"
+		snapGetKey := "volumesnapshots.snapshot.storage.k8s.io/get"
+		if scanAllNamespaces {
+			snapListKey = "volumesnapshots.snapshot.storage.k8s.io/list (all namespaces)"
+			snapGetKey = "volumesnapshots.snapshot.storage.k8s.io/get (all namespaces)"
+		}
 		requirements = append(requirements,
 			rbacRequirement{
-				key:       "volumesnapshots.snapshot.storage.k8s.io/list",
+				key:       snapListKey,
 				group:     "snapshot.storage.k8s.io",
 				version:   "v1",
 				resource:  "volumesnapshots",
 				verb:      "list",
-				namespace: namespace,
+				namespace: snapNS,
 			},
 			rbacRequirement{
-				key:       "volumesnapshots.snapshot.storage.k8s.io/get",
+				key:       snapGetKey,
 				group:     "snapshot.storage.k8s.io",
 				version:   "v1",
 				resource:  "volumesnapshots",
 				verb:      "get",
-				namespace: namespace,
+				namespace: snapNS,
 			},
 		)
 	}
@@ -76,7 +92,7 @@ func (c *client) ValidateRBACPermissions(ctx context.Context) (*RBACValidationRe
 		MissingPermissions:     append(missing, notes...),
 		PermissionChecks:       permissionChecks,
 		ServiceAccount:         "current",
-		Namespace:              namespace,
+		Namespace:              reportNamespace,
 	}, nil
 }
 
@@ -92,7 +108,7 @@ func (c *client) checkSelfSubjectAccess(ctx context.Context, req rbacRequirement
 		Version:  version,
 		Resource: req.resource,
 	}
-	if !req.clusterScoped {
+	if !req.clusterScoped && req.namespace != "" {
 		attrs.Namespace = req.namespace
 	}
 

--- a/go/pkg/k8s/rbac.go
+++ b/go/pkg/k8s/rbac.go
@@ -1,0 +1,114 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+
+	authorizationv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type rbacRequirement struct {
+	key             string
+	group           string
+	version         string
+	resource        string
+	verb            string
+	namespace       string
+	clusterScoped   bool
+}
+
+func (c *client) ValidateRBACPermissions(ctx context.Context) (*RBACValidationResult, error) {
+	namespace := c.config.Namespace
+	if namespace == "" {
+		namespace = "default"
+	}
+
+	requirements := []rbacRequirement{
+		{key: "persistentvolumes/list", resource: "persistentvolumes", verb: "list", clusterScoped: true},
+		{key: "persistentvolumes/get", resource: "persistentvolumes", verb: "get", clusterScoped: true},
+		{key: "persistentvolumeclaims/list", resource: "persistentvolumeclaims", verb: "list", namespace: namespace},
+		{key: "persistentvolumeclaims/get", resource: "persistentvolumeclaims", verb: "get", namespace: namespace},
+	}
+
+	if c.snapshotClient != nil {
+		requirements = append(requirements,
+			rbacRequirement{
+				key:       "volumesnapshots.snapshot.storage.k8s.io/list",
+				group:     "snapshot.storage.k8s.io",
+				version:   "v1",
+				resource:  "volumesnapshots",
+				verb:      "list",
+				namespace: namespace,
+			},
+			rbacRequirement{
+				key:       "volumesnapshots.snapshot.storage.k8s.io/get",
+				group:     "snapshot.storage.k8s.io",
+				version:   "v1",
+				resource:  "volumesnapshots",
+				verb:      "get",
+				namespace: namespace,
+			},
+		)
+	}
+
+	permissionChecks := make(map[string]bool, len(requirements))
+	var missing []string
+	var notes []string
+
+	for _, req := range requirements {
+		allowed, err := c.checkSelfSubjectAccess(ctx, req)
+		if err != nil {
+			return nil, fmt.Errorf("rbac validation failed for %s: %w", req.key, err)
+		}
+		permissionChecks[req.key] = allowed
+		if !allowed {
+			missing = append(missing, req.key)
+		}
+	}
+
+	if c.snapshotClient == nil {
+		notes = append(notes, "skipped: volumesnapshots (snapshot client unavailable)")
+	}
+
+	return &RBACValidationResult{
+		HasRequiredPermissions: len(missing) == 0,
+		MissingPermissions:     append(missing, notes...),
+		PermissionChecks:       permissionChecks,
+		ServiceAccount:         "current",
+		Namespace:              namespace,
+	}, nil
+}
+
+func (c *client) checkSelfSubjectAccess(ctx context.Context, req rbacRequirement) (bool, error) {
+	version := req.version
+	if version == "" {
+		version = "v1"
+	}
+
+	attrs := &authorizationv1.ResourceAttributes{
+		Verb:     req.verb,
+		Group:    req.group,
+		Version:  version,
+		Resource: req.resource,
+	}
+	if !req.clusterScoped {
+		attrs.Namespace = req.namespace
+	}
+
+	review := &authorizationv1.SelfSubjectAccessReview{
+		Spec: authorizationv1.SelfSubjectAccessReviewSpec{
+			ResourceAttributes: attrs,
+		},
+	}
+
+	result, err := c.clientset.AuthorizationV1().SelfSubjectAccessReviews().Create(
+		ctx,
+		review,
+		metav1.CreateOptions{},
+	)
+	if err != nil {
+		return false, err
+	}
+	return result.Status.Allowed, nil
+}

--- a/go/pkg/orphan/detector.go
+++ b/go/pkg/orphan/detector.go
@@ -3,9 +3,9 @@ package orphan
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
+	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
 	corev1 "k8s.io/api/core/v1"
 	"go.uber.org/zap"
 
@@ -299,18 +299,23 @@ func (d *Detector) detectOrphanedPVCs(ctx context.Context, namespace string) ([]
 
 // detectOrphanedSnapshots identifies snapshots without corresponding resources
 func (d *Detector) detectOrphanedSnapshots(ctx context.Context, namespace string) ([]OrphanedResource, int, error) {
-	// Get all volume snapshots from Kubernetes
 	k8sSnapshots, err := d.k8sClient.ListVolumeSnapshots(ctx, namespace)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to list Kubernetes snapshots: %w", err)
 	}
 
-	// Get all snapshots from TrueNAS
 	truenasSnapshots, err := d.truenasClient.ListSnapshots(ctx)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to list TrueNAS snapshots: %w", err)
 	}
 
+	return d.detectOrphanedSnapshotsFromLists(k8sSnapshots, truenasSnapshots)
+}
+
+func (d *Detector) detectOrphanedSnapshotsFromLists(
+	k8sSnapshots []snapshotv1.VolumeSnapshot,
+	truenasSnapshots []truenas.Snapshot,
+) ([]OrphanedResource, int, error) {
 	var orphaned []OrphanedResource
 	threshold := time.Now().Add(-d.config.AgeThreshold)
 
@@ -353,14 +358,15 @@ func (d *Detector) detectOrphanedSnapshots(ctx context.Context, namespace string
 		}
 	}
 
-	d.logger.Info("Snapshot orphan detection completed",
-		zap.String("namespace", namespace),
-		zap.Int("k8s_snapshots", len(k8sSnapshots)),
-		zap.Int("truenas_snapshots", len(truenasSnapshots)),
-		zap.Int("orphaned_snapshots", len(orphaned)),
-		zap.String("age_threshold", d.config.AgeThreshold.String()),
-		zap.String("retention_threshold", d.config.SnapshotRetention.String()),
-	)
+	if d.logger != nil {
+		d.logger.Info("Snapshot orphan detection completed",
+			zap.Int("k8s_snapshots", len(k8sSnapshots)),
+			zap.Int("truenas_snapshots", len(truenasSnapshots)),
+			zap.Int("orphaned_snapshots", len(orphaned)),
+			zap.String("age_threshold", d.config.AgeThreshold.String()),
+			zap.String("retention_threshold", d.config.SnapshotRetention.String()),
+		)
+	}
 
 	return orphaned, len(k8sSnapshots), nil
 }
@@ -376,16 +382,11 @@ func (d *Detector) hasCorrespondingTrueNASVolume(pv corev1.PersistentVolume, tru
 		return false
 	}
 
-	// Extract dataset name from volume handle
-	// Democratic-CSI typically uses formats like:
-	// - pool/dataset/volume-name
-	// - pool/dataset@snapshot-name
-	// - iqn.2005-10.org.freenas.ctl:volume-name
-	datasetName := d.extractDatasetFromVolumeHandle(volumeHandle)
+	datasetName := extractDatasetFromVolumeHandle(volumeHandle)
 
 	for _, volume := range truenasVolumes {
 		// Check various matching strategies
-		if d.volumeMatches(volume, volumeHandle, datasetName) {
+		if volumeMatches(volume, volumeHandle, datasetName) {
 			d.logger.Debug("Found matching TrueNAS volume for PV",
 				zap.String("pv_name", pv.Name),
 				zap.String("volume_handle", volumeHandle),
@@ -399,65 +400,16 @@ func (d *Detector) hasCorrespondingTrueNASVolume(pv corev1.PersistentVolume, tru
 	return false
 }
 
-// hasCorrespondingTrueNASSnapshot checks if a K8s snapshot has a corresponding TrueNAS snapshot
-func (d *Detector) hasCorrespondingTrueNASSnapshot(k8sSnapshot interface{}, truenasSnapshots []truenas.Snapshot) bool {
-	// This would need to be implemented based on the actual VolumeSnapshot type
-	// For now, return true to avoid false positives
-	return true
+func (d *Detector) hasCorrespondingTrueNASSnapshot(
+	k8sSnapshot snapshotv1.VolumeSnapshot,
+	truenasSnapshots []truenas.Snapshot,
+) bool {
+	return snapshotCorrelatesWithTrueNAS(k8sSnapshot, truenasSnapshots)
 }
 
-// hasCorrespondingK8sSnapshot checks if a TrueNAS snapshot has a corresponding K8s snapshot
-func (d *Detector) hasCorrespondingK8sSnapshot(truenasSnapshot truenas.Snapshot, k8sSnapshots interface{}) bool {
-	// This would need to be implemented based on the actual VolumeSnapshot type
-	// For now, return true to avoid false positives
-	return true
-}
-
-// extractDatasetFromVolumeHandle extracts the dataset name from a CSI volume handle
-func (d *Detector) extractDatasetFromVolumeHandle(volumeHandle string) string {
-	// Handle different volume handle formats
-	if strings.Contains(volumeHandle, "iqn.") {
-		// iSCSI format: iqn.2005-10.org.freenas.ctl:volume-name
-		parts := strings.Split(volumeHandle, ":")
-		if len(parts) > 1 {
-			return parts[len(parts)-1]
-		}
-	} else if strings.Contains(volumeHandle, "/") {
-		// Dataset format: pool/dataset/volume-name
-		parts := strings.Split(volumeHandle, "/")
-		if len(parts) > 0 {
-			return parts[len(parts)-1]
-		}
-	}
-
-	return volumeHandle
-}
-
-// volumeMatches checks if a TrueNAS volume matches the given identifiers
-func (d *Detector) volumeMatches(volume truenas.Volume, volumeHandle, datasetName string) bool {
-	// Direct name match
-	if volume.Name == datasetName || volume.Name == volumeHandle {
-		return true
-	}
-
-	// Check if volume ID contains the dataset name
-	if strings.Contains(volume.ID, datasetName) {
-		return true
-	}
-
-	// Check if volume path contains the dataset name
-	if strings.Contains(volume.Path, datasetName) {
-		return true
-	}
-
-	// Check properties for additional matching
-	if volume.Properties != nil {
-		for _, value := range volume.Properties {
-			if strings.Contains(value, datasetName) {
-				return true
-			}
-		}
-	}
-
-	return false
+func (d *Detector) hasCorrespondingK8sSnapshot(
+	truenasSnapshot truenas.Snapshot,
+	k8sSnapshots []snapshotv1.VolumeSnapshot,
+) bool {
+	return truenasSnapshotCorrelatesWithK8s(truenasSnapshot, k8sSnapshots)
 }

--- a/go/pkg/orphan/detector_test.go
+++ b/go/pkg/orphan/detector_test.go
@@ -1,0 +1,231 @@
+package orphan
+
+import (
+	"testing"
+	"time"
+
+	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
+	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/truenas"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestExtractDatasetFromVolumeHandle(t *testing.T) {
+	tests := []struct {
+		name    string
+		handle  string
+		want    string
+	}{
+		{"iscsi handle", "iqn.2005-10.org.freenas.ctl:my-volume", "my-volume"},
+		{"zfs path handle", "tank/k8s/vol-1", "vol-1"},
+		{"plain handle", "standalone-id", "standalone-id"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractDatasetFromVolumeHandle(tt.handle)
+			if got != tt.want {
+				t.Fatalf("extractDatasetFromVolumeHandle(%q) = %q, want %q", tt.handle, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVolumeMatches(t *testing.T) {
+	tests := []struct {
+		name         string
+		volume       truenas.Volume
+		volumeHandle string
+		datasetName  string
+		want         bool
+	}{
+		{
+			name:         "direct name match",
+			volume:       truenas.Volume{Name: "vol-1"},
+			volumeHandle: "tank/k8s/vol-1",
+			datasetName:  "vol-1",
+			want:         true,
+		},
+		{
+			name:         "path contains dataset",
+			volume:       truenas.Volume{Name: "other", Path: "/mnt/tank/k8s/vol-1"},
+			volumeHandle: "tank/k8s/vol-1",
+			datasetName:  "vol-1",
+			want:         true,
+		},
+		{
+			name: "unrelated property substring does not match",
+			volume: truenas.Volume{
+				Name:       "unrelated",
+				Properties: map[string]string{"note": "prefix-vol-1-suffix"},
+			},
+			volumeHandle: "tank/k8s/vol-1",
+			datasetName:  "vol-1",
+			want:         false,
+		},
+		{
+			name:         "no match",
+			volume:       truenas.Volume{Name: "other-vol"},
+			volumeHandle: "tank/k8s/vol-1",
+			datasetName:  "vol-1",
+			want:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := volumeMatches(tt.volume, tt.volumeHandle, tt.datasetName)
+			if got != tt.want {
+				t.Fatalf("volumeMatches() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSnapshotCorrelatesWithTrueNAS(t *testing.T) {
+	old := time.Now().Add(-48 * time.Hour)
+	k8sSnap := snapshotv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "snap-a",
+			Namespace:         "apps",
+			CreationTimestamp: metav1.NewTime(old),
+		},
+	}
+
+	tests := []struct {
+		name     string
+		truenas  []truenas.Snapshot
+		want     bool
+	}{
+		{
+			name: "matching snapshot name",
+			truenas: []truenas.Snapshot{
+				{Name: "snap-a", Dataset: "tank/k8s/vol-1"},
+			},
+			want: true,
+		},
+		{
+			name: "matching dataset@name",
+			truenas: []truenas.Snapshot{
+				{Name: "snap-a", Dataset: "tank/k8s/vol-1"},
+			},
+			want: true,
+		},
+		{
+			name: "full zfs snapshot id",
+			truenas: []truenas.Snapshot{
+				{Name: "tank/k8s/vol-1@snap-a", Dataset: "tank/k8s/vol-1"},
+			},
+			want: true,
+		},
+		{
+			name: "no peer",
+			truenas: []truenas.Snapshot{
+				{Name: "other-snap", Dataset: "tank/k8s/vol-2"},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := snapshotCorrelatesWithTrueNAS(k8sSnap, tt.truenas)
+			if got != tt.want {
+				t.Fatalf("snapshotCorrelatesWithTrueNAS() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTruenasSnapshotCorrelatesWithK8s(t *testing.T) {
+	old := metav1.NewTime(time.Now().Add(-48 * time.Hour))
+	k8sSnaps := []snapshotv1.VolumeSnapshot{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "snap-a",
+				Namespace:         "apps",
+				CreationTimestamp: old,
+			},
+		},
+	}
+
+	tests := []struct {
+		name    string
+		truenas truenas.Snapshot
+		want    bool
+	}{
+		{
+			name:    "name match",
+			truenas: truenas.Snapshot{Name: "snap-a", Dataset: "tank/k8s/vol-1"},
+			want:    true,
+		},
+		{
+			name:    "full id match",
+			truenas: truenas.Snapshot{Name: "tank/k8s/vol-1@snap-a", Dataset: "tank/k8s/vol-1"},
+			want:    true,
+		},
+		{
+			name:    "orphan on truenas side",
+			truenas: truenas.Snapshot{Name: "orphan-snap", Dataset: "tank/k8s/vol-9"},
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := truenasSnapshotCorrelatesWithK8s(tt.truenas, k8sSnaps)
+			if got != tt.want {
+				t.Fatalf("truenasSnapshotCorrelatesWithK8s() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectOrphanedSnapshots_FlagsMissingPeers(t *testing.T) {
+	threshold := 24 * time.Hour
+	old := metav1.NewTime(time.Now().Add(-48 * time.Hour))
+
+	d := &Detector{
+		config: Config{
+			AgeThreshold:      threshold,
+			SnapshotRetention: 30 * 24 * time.Hour,
+		},
+	}
+
+	k8sSnaps := []snapshotv1.VolumeSnapshot{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "k8s-only",
+				CreationTimestamp: old,
+			},
+		},
+	}
+	truenasSnaps := []truenas.Snapshot{
+		{
+			Name:      "truenas-only",
+			Dataset:   "tank/k8s/vol-1",
+			CreatedAt: time.Now().Add(-60 * 24 * time.Hour),
+		},
+	}
+
+	orphaned, total, err := d.detectOrphanedSnapshotsFromLists(k8sSnaps, truenasSnaps)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if total != 1 {
+		t.Fatalf("total snapshots = %d, want 1", total)
+	}
+	if len(orphaned) != 2 {
+		t.Fatalf("orphaned count = %d, want 2 (one k8s-only, one truenas-only)", len(orphaned))
+	}
+}
+
+func TestHasCorrespondingTrueNASVolume_EmptyCSI(t *testing.T) {
+	d := &Detector{}
+	pv := corev1.PersistentVolume{
+		Spec: corev1.PersistentVolumeSpec{},
+	}
+	if d.hasCorrespondingTrueNASVolume(pv, nil) {
+		t.Fatal("expected false when PV has no CSI source")
+	}
+}

--- a/go/pkg/orphan/detector_test.go
+++ b/go/pkg/orphan/detector_test.go
@@ -12,13 +12,15 @@ import (
 
 func TestExtractDatasetFromVolumeHandle(t *testing.T) {
 	tests := []struct {
-		name    string
-		handle  string
-		want    string
+		name   string
+		handle string
+		want   string
 	}{
 		{"iscsi handle", "iqn.2005-10.org.freenas.ctl:my-volume", "my-volume"},
 		{"zfs path handle", "tank/k8s/vol-1", "vol-1"},
 		{"plain handle", "standalone-id", "standalone-id"},
+		{"zfs snapshot suffix stripped", "tank/k8s/vol-1@daily", "vol-1"},
+		{"malformed iscsi trailing colon yields empty token", "iqn.2005-10.org.freenas.ctl:", ""},
 	}
 
 	for _, tt := range tests {
@@ -47,20 +49,44 @@ func TestVolumeMatches(t *testing.T) {
 			want:         true,
 		},
 		{
-			name:         "path contains dataset",
+			name:         "path suffix match",
 			volume:       truenas.Volume{Name: "other", Path: "/mnt/tank/k8s/vol-1"},
 			volumeHandle: "tank/k8s/vol-1",
 			datasetName:  "vol-1",
 			want:         true,
 		},
 		{
-			name: "unrelated property substring does not match",
+			name: "property exact match restored",
+			volume: truenas.Volume{
+				Name:       "unrelated",
+				Properties: map[string]string{"zfs:dataset": "tank/k8s/vol-1"},
+			},
+			volumeHandle: "tank/k8s/vol-1",
+			datasetName:  "vol-1",
+			want:         true,
+		},
+		{
+			name: "property substring collision avoided",
 			volume: truenas.Volume{
 				Name:       "unrelated",
 				Properties: map[string]string{"note": "prefix-vol-1-suffix"},
 			},
 			volumeHandle: "tank/k8s/vol-1",
 			datasetName:  "vol-1",
+			want:         false,
+		},
+		{
+			name:         "vol-1 does not match vol-10 path",
+			volume:       truenas.Volume{Path: "/mnt/tank/k8s/vol-10"},
+			volumeHandle: "tank/k8s/vol-1",
+			datasetName:  "vol-1",
+			want:         false,
+		},
+		{
+			name:         "empty dataset token never matches",
+			volume:       truenas.Volume{ID: "anything"},
+			volumeHandle: "tank/k8s/",
+			datasetName:  "",
 			want:         false,
 		},
 		{
@@ -86,42 +112,45 @@ func TestSnapshotCorrelatesWithTrueNAS(t *testing.T) {
 	old := time.Now().Add(-48 * time.Hour)
 	k8sSnap := snapshotv1.VolumeSnapshot{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:              "snap-a",
+			Name:              "daily",
 			Namespace:         "apps",
 			CreationTimestamp: metav1.NewTime(old),
+			Annotations: map[string]string{
+				"zfs.dataset": "tank/k8s/vol-1",
+			},
 		},
 	}
 
 	tests := []struct {
-		name     string
-		truenas  []truenas.Snapshot
-		want     bool
+		name    string
+		truenas []truenas.Snapshot
+		want    bool
 	}{
 		{
-			name: "matching snapshot name",
+			name: "matching name and dataset",
 			truenas: []truenas.Snapshot{
-				{Name: "snap-a", Dataset: "tank/k8s/vol-1"},
+				{Name: "daily", Dataset: "tank/k8s/vol-1"},
 			},
 			want: true,
 		},
 		{
-			name: "matching dataset@name",
+			name: "full zfs snapshot id with dataset hint",
 			truenas: []truenas.Snapshot{
-				{Name: "snap-a", Dataset: "tank/k8s/vol-1"},
+				{Name: "tank/k8s/vol-1@daily", Dataset: "tank/k8s/vol-1"},
 			},
 			want: true,
 		},
 		{
-			name: "full zfs snapshot id",
+			name: "same snapshot name on different dataset is not a peer",
 			truenas: []truenas.Snapshot{
-				{Name: "tank/k8s/vol-1@snap-a", Dataset: "tank/k8s/vol-1"},
+				{Name: "daily", Dataset: "tank/k8s/vol-2"},
 			},
-			want: true,
+			want: false,
 		},
 		{
 			name: "no peer",
 			truenas: []truenas.Snapshot{
-				{Name: "other-snap", Dataset: "tank/k8s/vol-2"},
+				{Name: "other-snap", Dataset: "tank/k8s/vol-9"},
 			},
 			want: false,
 		},
@@ -145,6 +174,15 @@ func TestTruenasSnapshotCorrelatesWithK8s(t *testing.T) {
 				Name:              "snap-a",
 				Namespace:         "apps",
 				CreationTimestamp: old,
+				Annotations: map[string]string{
+					"zfs.dataset": "tank/k8s/vol-1",
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "tank/k8s/vol-1@snap-a",
+				CreationTimestamp: old,
 			},
 		},
 	}
@@ -155,12 +193,12 @@ func TestTruenasSnapshotCorrelatesWithK8s(t *testing.T) {
 		want    bool
 	}{
 		{
-			name:    "name match",
+			name:    "name and dataset hint match",
 			truenas: truenas.Snapshot{Name: "snap-a", Dataset: "tank/k8s/vol-1"},
 			want:    true,
 		},
 		{
-			name:    "full id match",
+			name:    "full zfs id matches k8s object named with full id",
 			truenas: truenas.Snapshot{Name: "tank/k8s/vol-1@snap-a", Dataset: "tank/k8s/vol-1"},
 			want:    true,
 		},

--- a/go/pkg/orphan/matching.go
+++ b/go/pkg/orphan/matching.go
@@ -25,14 +25,80 @@ func truenasSnapshotComponentName(s truenas.Snapshot) string {
 	return s.Name
 }
 
-func snapshotCorrelatesWithTrueNAS(k8s snapshotv1.VolumeSnapshot, truenasSnapshots []truenas.Snapshot) bool {
-	k8sName := k8s.Name
-	for _, tn := range truenasSnapshots {
-		full := truenasSnapshotFullName(tn)
-		if tn.Name == k8sName || full == k8sName || strings.HasSuffix(full, "@"+k8sName) {
+func snapshotNameMatches(k8sName string, tn truenas.Snapshot) bool {
+	full := truenasSnapshotFullName(tn)
+	component := truenasSnapshotComponentName(tn)
+	return tn.Name == k8sName || full == k8sName || strings.HasSuffix(full, "@"+k8sName) || component == k8sName
+}
+
+func k8sSnapshotDatasetHints(k8s snapshotv1.VolumeSnapshot) []string {
+	var hints []string
+	add := func(s string) {
+		s = strings.TrimSpace(s)
+		if s != "" {
+			hints = append(hints, s)
+		}
+	}
+
+	for _, m := range []map[string]string{k8s.Labels, k8s.Annotations} {
+		for _, v := range m {
+			if strings.Contains(v, "/") {
+				add(v)
+			}
+		}
+	}
+
+	if k8s.Spec.Source.PersistentVolumeClaimName != nil {
+		pvc := *k8s.Spec.Source.PersistentVolumeClaimName
+		add(pvc)
+		if k8s.Namespace != "" {
+			add(k8s.Namespace + "/" + pvc)
+		}
+	}
+	if k8s.Spec.Source.VolumeSnapshotContentName != nil {
+		add(*k8s.Spec.Source.VolumeSnapshotContentName)
+	}
+	if k8s.Status != nil && k8s.Status.BoundVolumeSnapshotContentName != nil {
+		add(*k8s.Status.BoundVolumeSnapshotContentName)
+	}
+
+	return hints
+}
+
+func truenasDatasetMatchesHints(dataset string, hints []string) bool {
+	dataset = strings.Trim(dataset, "/")
+	if dataset == "" {
+		return false
+	}
+	for _, hint := range hints {
+		hint = strings.Trim(hint, "/")
+		if hint == dataset {
 			return true
 		}
-		if component := truenasSnapshotComponentName(tn); component == k8sName {
+		if strings.HasSuffix(hint, "/"+dataset) || strings.HasSuffix(dataset, "/"+hint) {
+			return true
+		}
+	}
+	return false
+}
+
+func snapshotCorrelatesPair(k8s snapshotv1.VolumeSnapshot, tn truenas.Snapshot) bool {
+	if !snapshotNameMatches(k8s.Name, tn) {
+		return false
+	}
+
+	hints := k8sSnapshotDatasetHints(k8s)
+	if len(hints) == 0 {
+		return truenasSnapshotFullName(tn) == k8s.Name
+	}
+
+	return truenasDatasetMatchesHints(tn.Dataset, hints) ||
+		truenasDatasetMatchesHints(truenasSnapshotFullName(tn), hints)
+}
+
+func snapshotCorrelatesWithTrueNAS(k8s snapshotv1.VolumeSnapshot, truenasSnapshots []truenas.Snapshot) bool {
+	for _, tn := range truenasSnapshots {
+		if snapshotCorrelatesPair(k8s, tn) {
 			return true
 		}
 	}
@@ -40,10 +106,8 @@ func snapshotCorrelatesWithTrueNAS(k8s snapshotv1.VolumeSnapshot, truenasSnapsho
 }
 
 func truenasSnapshotCorrelatesWithK8s(tn truenas.Snapshot, k8sSnapshots []snapshotv1.VolumeSnapshot) bool {
-	component := truenasSnapshotComponentName(tn)
-	full := truenasSnapshotFullName(tn)
 	for _, ks := range k8sSnapshots {
-		if ks.Name == component || ks.Name == tn.Name || ks.Name == full {
+		if snapshotCorrelatesPair(ks, tn) {
 			return true
 		}
 	}
@@ -51,29 +115,51 @@ func truenasSnapshotCorrelatesWithK8s(tn truenas.Snapshot, k8sSnapshots []snapsh
 }
 
 func extractDatasetFromVolumeHandle(volumeHandle string) string {
-	if strings.Contains(volumeHandle, "iqn.") {
-		parts := strings.Split(volumeHandle, ":")
-		if len(parts) > 1 {
-			return parts[len(parts)-1]
+	handle := strings.TrimSpace(volumeHandle)
+	if strings.Contains(handle, "iqn.") {
+		handle = strings.TrimRight(handle, ":")
+		if idx := strings.LastIndex(handle, ":"); idx >= 0 && idx+1 < len(handle) {
+			handle = handle[idx+1:]
+		} else {
+			return ""
 		}
-	} else if strings.Contains(volumeHandle, "/") {
-		parts := strings.Split(volumeHandle, "/")
-		if len(parts) > 0 {
-			return parts[len(parts)-1]
+	} else {
+		handle = strings.TrimRight(handle, "/")
+		if idx := strings.LastIndex(handle, "/"); idx >= 0 && idx+1 < len(handle) {
+			handle = handle[idx+1:]
 		}
 	}
-	return volumeHandle
+
+	if idx := strings.LastIndex(handle, "@"); idx >= 0 {
+		handle = handle[:idx]
+	}
+	return strings.TrimSpace(handle)
 }
 
 func volumeMatches(volume truenas.Volume, volumeHandle, datasetName string) bool {
+	if datasetName == "" {
+		return false
+	}
 	if volume.Name == datasetName || volume.Name == volumeHandle {
 		return true
 	}
-	if strings.Contains(volume.ID, datasetName) {
+	if volume.ID == datasetName ||
+		strings.HasSuffix(volume.ID, "/"+datasetName) ||
+		strings.HasSuffix(volume.ID, ":"+datasetName) {
 		return true
 	}
-	if strings.Contains(volume.Path, datasetName) {
+	path := strings.TrimRight(volume.Path, "/")
+	if path == datasetName || strings.HasSuffix(path, "/"+datasetName) {
 		return true
+	}
+	if volume.Properties != nil {
+		for _, value := range volume.Properties {
+			if value == datasetName ||
+				strings.HasSuffix(value, "/"+datasetName) ||
+				strings.HasSuffix(value, ":"+datasetName) {
+				return true
+			}
+		}
 	}
 	return false
 }

--- a/go/pkg/orphan/matching.go
+++ b/go/pkg/orphan/matching.go
@@ -1,0 +1,79 @@
+package orphan
+
+import (
+	"strings"
+
+	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
+	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/truenas"
+)
+
+func truenasSnapshotFullName(s truenas.Snapshot) string {
+	if strings.Contains(s.Name, "@") {
+		return s.Name
+	}
+	if s.Dataset != "" && s.Name != "" {
+		return s.Dataset + "@" + s.Name
+	}
+	return s.Name
+}
+
+func truenasSnapshotComponentName(s truenas.Snapshot) string {
+	full := truenasSnapshotFullName(s)
+	if idx := strings.LastIndex(full, "@"); idx >= 0 {
+		return full[idx+1:]
+	}
+	return s.Name
+}
+
+func snapshotCorrelatesWithTrueNAS(k8s snapshotv1.VolumeSnapshot, truenasSnapshots []truenas.Snapshot) bool {
+	k8sName := k8s.Name
+	for _, tn := range truenasSnapshots {
+		full := truenasSnapshotFullName(tn)
+		if tn.Name == k8sName || full == k8sName || strings.HasSuffix(full, "@"+k8sName) {
+			return true
+		}
+		if component := truenasSnapshotComponentName(tn); component == k8sName {
+			return true
+		}
+	}
+	return false
+}
+
+func truenasSnapshotCorrelatesWithK8s(tn truenas.Snapshot, k8sSnapshots []snapshotv1.VolumeSnapshot) bool {
+	component := truenasSnapshotComponentName(tn)
+	full := truenasSnapshotFullName(tn)
+	for _, ks := range k8sSnapshots {
+		if ks.Name == component || ks.Name == tn.Name || ks.Name == full {
+			return true
+		}
+	}
+	return false
+}
+
+func extractDatasetFromVolumeHandle(volumeHandle string) string {
+	if strings.Contains(volumeHandle, "iqn.") {
+		parts := strings.Split(volumeHandle, ":")
+		if len(parts) > 1 {
+			return parts[len(parts)-1]
+		}
+	} else if strings.Contains(volumeHandle, "/") {
+		parts := strings.Split(volumeHandle, "/")
+		if len(parts) > 0 {
+			return parts[len(parts)-1]
+		}
+	}
+	return volumeHandle
+}
+
+func volumeMatches(volume truenas.Volume, volumeHandle, datasetName string) bool {
+	if volume.Name == datasetName || volume.Name == volumeHandle {
+		return true
+	}
+	if strings.Contains(volume.ID, datasetName) {
+		return true
+	}
+	if strings.Contains(volume.Path, datasetName) {
+		return true
+	}
+	return false
+}

--- a/go/pkg/orphan/matching.go
+++ b/go/pkg/orphan/matching.go
@@ -50,7 +50,6 @@ func k8sSnapshotDatasetHints(k8s snapshotv1.VolumeSnapshot) []string {
 
 	if k8s.Spec.Source.PersistentVolumeClaimName != nil {
 		pvc := *k8s.Spec.Source.PersistentVolumeClaimName
-		add(pvc)
 		if k8s.Namespace != "" {
 			add(k8s.Namespace + "/" + pvc)
 		}


### PR DESCRIPTION
## Summary

Implements [PR 5 — Orphan Detection and Validation Debt](docs/superpowers/plans/2026-05-28-repo-health-remediation.md) from the repo health remediation plan (M2: Contract Integrity).

- Replace always-`true` snapshot correlation stubs with deterministic K8s ↔ TrueNAS matching (`go/pkg/orphan/matching.go`).
- Remove broad property substring volume matching that caused false positives.
- Replace optimistic `ValidateRBACPermissions` with SelfSubjectAccessReview checks for required PV/PVC (and VolumeSnapshot when client is configured).
- Add table-driven tests in `go/pkg/orphan/detector_test.go` and `go/pkg/k8s/client_test.go`.

**Spec:** [docs/superpowers/specs/2026-05-28-pr-5-detector-validation-design.md](docs/superpowers/specs/2026-05-28-pr-5-detector-validation-design.md)

## Test plan

- [x] `make go-test`
- [x] `cd go && go vet ./...`
- [x] `make go-lint`

## Mandatory PR checklist

- [x] **Scope:** Maps to one plan item (PR 5).
- [x] **Correctness:** Added/updated tests for changed logic.
- [x] **Regression Safety:** Relevant existing tests pass.
- [x] **Security:** No insecure defaults; SSAR uses current credentials only.
- [x] **Reliability:** RBAC failures surface explicitly; snapshot client skip is documented in result.
- [x] **Performance:** No new unbounded loops; matching is O(n×m) over snapshot lists (unchanged scale).
- [x] **Docs:** Plan + design spec updated.
- [ ] **Ops/Runbook:** Snapshot orphan counts may increase from zero after deploy (expected honesty fix per spec).
- [x] **Verification Evidence:** `make go-test`, `go vet`, `make go-lint` (local).
- [x] **Tracking:** Plan acceptance criteria marked; PR URL to be added after open.

## Rollout note

Deploying this change may report non-zero snapshot orphans where PR 4 previously returned none, because snapshot matching is no longer a no-op.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Real RBAC permission checks now report missing or skipped snapshot permissions.
  * Snapshot orphan detection uses deterministic correlation instead of treating all snapshots as matching.
  * Improved behavior when the snapshot client is unavailable.

* **Tests**
  * Added comprehensive, table-driven unit tests for RBAC validation and orphan detection.

* **Documentation**
  * Updated design spec and plan; related acceptance criteria marked completed and status advanced.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tomazb/kubernetes-truenas-democratic-tool/pull/55?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->