### PR TITLE
feat(reliability): rate limits, transient retries, nil-safe metrics (PR 6)

### DIFF
--- a/docs/superpowers/plans/2026-05-28-repo-health-remediation.md
+++ b/docs/superpowers/plans/2026-05-28-repo-health-remediation.md
@@ -95,11 +95,11 @@ Suggested worktree layout:
 
 ## Overall Status
 
-- **Current phase:** Phase 2 - Contract integrity (PR 5 next)
+- **Current phase:** Phase 3 - Operational readiness (PR 6 in progress)
 - **Primary owner:** TBD
 - **Last updated:** 2026-05-30
-- **Last merged:** PR 4 API honesty [#54](https://github.com/tomazb/kubernetes-truenas-democratic-tool/pull/54) (2026-05-30)
-- **Next up:** PR 5 - Orphan detection and validation debt
+- **Last merged:** PR 5 detector validation [#55](https://github.com/tomazb/kubernetes-truenas-democratic-tool/pull/55) (2026-05-30)
+- **Next up:** PR 6 - Reliability and performance guardrails
 
 ## Milestones
 
@@ -263,7 +263,7 @@ Suggested worktree layout:
 
 ### PR 5: Orphan Detection and Validation Debt
 
-- **Status:** In Progress
+- **Status:** Done
 - **Risk:** High
 - **Focus:** Replace hardcoded detector logic and optimistic validation stubs.
 - **Branch/worktree:**
@@ -288,7 +288,7 @@ Suggested worktree layout:
 
 ### PR 6: Reliability and Performance Guardrails
 
-- **Status:** Planned
+- **Status:** In Progress
 - **Risk:** Medium
 - **Focus:** Improve resilience and fairness under load/failures.
 - **Branch/worktree:**
@@ -301,15 +301,15 @@ Suggested worktree layout:
   - `go/pkg/k8s/client.go`
   - Corresponding tests
 - **Implementation steps:**
-  - [ ] Replace global rate limiter with per-client limiter strategy.
-  - [ ] Add limiter eviction/cleanup to prevent unbounded growth.
-  - [ ] Guard nil metrics exporter paths to prevent panics.
-  - [ ] Restrict retries to transient error classes.
-  - [ ] Add tests for limiter fairness and retry predicates.
+  - [x] Replace global rate limiter with per-client limiter strategy.
+  - [x] Add limiter eviction/cleanup to prevent unbounded growth.
+  - [x] Guard nil metrics exporter paths to prevent panics.
+  - [x] Restrict retries to transient error classes.
+  - [x] Add tests for limiter fairness and retry predicates.
 - **Acceptance criteria:**
-  - [ ] No nil exporter panic path.
-  - [ ] No global limiter starvation by a single noisy client.
-  - [ ] Retry behavior avoids repeated non-transient failures.
+  - [x] No nil exporter panic path.
+  - [x] No global limiter starvation by a single noisy client.
+  - [x] Retry behavior avoids repeated non-transient failures.
 - **PR URL:** TBD
 
 ### PR 7: Test and CI/Release Trustworthiness

--- a/docs/superpowers/plans/2026-05-28-repo-health-remediation.md
+++ b/docs/superpowers/plans/2026-05-28-repo-health-remediation.md
@@ -310,7 +310,7 @@ Suggested worktree layout:
   - [x] No nil exporter panic path.
   - [x] No global limiter starvation by a single noisy client.
   - [x] Retry behavior avoids repeated non-transient failures.
-- **PR URL:** TBD
+- **PR URL:** https://github.com/tomazb/kubernetes-truenas-democratic-tool/pull/56
 
 ### PR 7: Test and CI/Release Trustworthiness
 

--- a/docs/superpowers/specs/2026-05-28-pr-6-reliability-performance-design.md
+++ b/docs/superpowers/specs/2026-05-28-pr-6-reliability-performance-design.md
@@ -1,0 +1,56 @@
+# PR 6: Reliability and Performance Guardrails — Design Spec
+
+**Date:** 2026-05-28  
+**Plan item:** [Remediation plan PR 6](../plans/2026-05-28-repo-health-remediation.md)  
+**Milestone:** M3 — Operational Readiness
+
+## Problem statement and scope
+
+Runtime paths can fail or degrade under load:
+
+- API rate limiting uses one global `rate.Limiter`, so a single client can exhaust quota for all callers.
+- Per-client limiter map has no eviction and could grow without bound if many unique client keys appear.
+- `monitor.Service` dereferences `metricsExporter` without nil checks (panic if unset).
+- Kubernetes client retries retry on **any** error (`return err != nil`), including permanent API failures (404/403), wasting time and log noise.
+
+**In scope:**
+
+- Per-client API rate limiting with idle eviction
+- Nil-safe metrics updates in monitor service
+- Transient-only retry predicate for k8s list/get operations
+- Unit tests for limiter fairness, eviction, retry classification, nil exporter
+
+**Out of scope:**
+
+- Configurable rate limits from YAML (existing `security.rate_limit_rps` validation only)
+- Full monitor horizontal scaling / watch-based detection
+- TrueNAS client retry policy (separate backlog if needed)
+
+## Current vs target behavior
+
+| Area | Current | Target |
+|------|---------|--------|
+| API rate limit | Global limiter | Per `ClientIP()` limiter with TTL eviction |
+| Limiter map | N/A (single limiter) | Evict idle clients; cap map growth |
+| Monitor metrics | Panic if exporter nil | Skip metric updates when nil |
+| K8s retries | Retry all errors | Retry timeouts, 429, 5xx, transient net errors only |
+
+## Technical approach
+
+1. Add `go/pkg/api/ratelimit.go` with `perClientRateLimiter` and wire middleware in `server.go`.
+2. Add `go/pkg/k8s/retry.go` with `isTransientK8sError` used by all `retry.OnError` call sites in `client.go`.
+3. Guard `metricsExporter` in `monitor/service.go` Start/Stop/updateMetrics.
+4. Table-driven tests in `*_test.go` files.
+
+## Test strategy
+
+```bash
+cd go && go test ./pkg/api/... ./pkg/k8s/... ./pkg/monitor/... -v
+make go-test && make go-lint
+```
+
+## Rollout and backout
+
+**Rollout:** Deploy updated API/monitor binaries. Rate limits apply per source IP; noisy clients no longer starve others.
+
+**Backout:** Revert PR; restores global limiter and permissive retries.

--- a/docs/superpowers/specs/2026-05-28-pr-6-reliability-performance-design.md
+++ b/docs/superpowers/specs/2026-05-28-pr-6-reliability-performance-design.md
@@ -30,7 +30,7 @@ Runtime paths can fail or degrade under load:
 
 | Area | Current | Target |
 |------|---------|--------|
-| API rate limit | Global limiter | Per `ClientIP()` limiter with TTL eviction |
+| API rate limit | Global limiter | Per client key with TTL eviction (RemoteAddr unless trusted proxies configured) |
 | Limiter map | N/A (single limiter) | Evict idle clients; cap map growth |
 | Monitor metrics | Panic if exporter nil | Skip metric updates when nil |
 | K8s retries | Retry all errors | Retry timeouts, 429, 5xx, transient net errors only |
@@ -42,10 +42,23 @@ Runtime paths can fail or degrade under load:
 3. Guard `metricsExporter` in `monitor/service.go` Start/Stop/updateMetrics.
 4. Table-driven tests in `*_test.go` files.
 
+## Risk, failure modes, and mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Limiter map growth under many unique client keys | Idle TTL eviction + max entry cap with oldest-first trim |
+| Hot-path eviction overhead | Evict only when inserting a new client key |
+| Spoofed `X-Forwarded-For` bypass | `SetTrustedProxies(nil)` by default; optional `TrustedProxies` CIDR list for ingress |
+| Wrong `retry_after` for custom limiter rates | Derive from limiter `rate.Limit` + set HTTP `Retry-After` header |
+| Nil metrics exporter panic | Guard Start/Stop/updateMetrics when exporter unset |
+| Missing retries on transient K8s errors | `isTransientK8sError` table-tested; permanent errors fail fast |
+| Over-aggressive retry suppression | Monitor 429/5xx retry metrics in ops backlog; tune predicate if needed |
+
 ## Test strategy
 
 ```bash
 cd go && go test ./pkg/api/... ./pkg/k8s/... ./pkg/monitor/... -v
+cd go && go vet ./...
 make go-test && make go-lint
 ```
 

--- a/go/pkg/api/ratelimit.go
+++ b/go/pkg/api/ratelimit.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"fmt"
 	"net/http"
 	"sync"
 	"time"
@@ -59,19 +60,28 @@ func (p *perClientRateLimiter) allow(clientKey string) bool {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	p.evictLocked(now)
-
 	entry, ok := p.clients[clientKey]
 	if !ok {
+		p.evictLocked(now)
 		entry = &clientLimiterEntry{
 			limiter:  rate.NewLimiter(p.limit, p.burst),
 			lastSeen: now,
 		}
 		p.clients[clientKey] = entry
+		if len(p.clients) > p.maxEntries {
+			p.evictLocked(now)
+		}
 	}
 
 	entry.lastSeen = now
 	return entry.limiter.Allow()
+}
+
+func (p *perClientRateLimiter) retryAfter() time.Duration {
+	if p.limit <= 0 {
+		return time.Second
+	}
+	return time.Duration(float64(time.Second) / float64(p.limit))
 }
 
 func (p *perClientRateLimiter) evictLocked(now time.Time) {
@@ -85,7 +95,6 @@ func (p *perClientRateLimiter) evictLocked(now time.Time) {
 		return
 	}
 
-	// Drop oldest entries when over capacity.
 	for len(p.clients) > p.maxEntries {
 		var oldestKey string
 		var oldestTime time.Time
@@ -110,21 +119,32 @@ func (p *perClientRateLimiter) clientCount() int {
 	return len(p.clients)
 }
 
+func clientRateLimitKey(c *gin.Context) string {
+	// ClientIP() honors engine trusted-proxy settings configured in NewServer.
+	if ip := c.ClientIP(); ip != "" {
+		return ip
+	}
+	return "unknown"
+}
+
 func perClientRateLimitMiddleware(limiter *perClientRateLimiter) gin.HandlerFunc {
 	if limiter == nil {
 		limiter = newPerClientRateLimiter(defaultRequestsPerMinute, defaultRateBurst, defaultClientIdleTTL, defaultMaxClientEntries)
 	}
 
 	return func(c *gin.Context) {
-		clientKey := c.ClientIP()
-		if clientKey == "" {
-			clientKey = "unknown"
-		}
+		clientKey := clientRateLimitKey(c)
 
 		if !limiter.allow(clientKey) {
+			retryAfter := limiter.retryAfter()
+			retryAfterSec := int(retryAfter.Seconds())
+			if retryAfterSec < 1 {
+				retryAfterSec = 1
+			}
+			c.Header("Retry-After", fmt.Sprintf("%d", retryAfterSec))
 			c.JSON(http.StatusTooManyRequests, gin.H{
 				"error":       "rate limit exceeded",
-				"retry_after": (time.Minute / time.Duration(defaultRequestsPerMinute)).String(),
+				"retry_after": retryAfter.String(),
 			})
 			c.Abort()
 			return

--- a/go/pkg/api/ratelimit.go
+++ b/go/pkg/api/ratelimit.go
@@ -1,0 +1,134 @@
+package api
+
+import (
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"golang.org/x/time/rate"
+)
+
+const (
+	defaultRequestsPerMinute = 100
+	defaultRateBurst         = 100
+	defaultClientIdleTTL     = 10 * time.Minute
+	defaultMaxClientEntries  = 4096
+)
+
+type perClientRateLimiter struct {
+	mu         sync.Mutex
+	clients    map[string]*clientLimiterEntry
+	limit      rate.Limit
+	burst      int
+	idleTTL    time.Duration
+	maxEntries int
+}
+
+type clientLimiterEntry struct {
+	limiter  *rate.Limiter
+	lastSeen time.Time
+}
+
+func newPerClientRateLimiter(requestsPerMinute, burst int, idleTTL time.Duration, maxEntries int) *perClientRateLimiter {
+	if requestsPerMinute <= 0 {
+		requestsPerMinute = defaultRequestsPerMinute
+	}
+	if burst <= 0 {
+		burst = requestsPerMinute
+	}
+	if idleTTL <= 0 {
+		idleTTL = defaultClientIdleTTL
+	}
+	if maxEntries <= 0 {
+		maxEntries = defaultMaxClientEntries
+	}
+
+	return &perClientRateLimiter{
+		clients:    make(map[string]*clientLimiterEntry),
+		limit:      rate.Limit(float64(requestsPerMinute) / 60.0),
+		burst:      burst,
+		idleTTL:    idleTTL,
+		maxEntries: maxEntries,
+	}
+}
+
+func (p *perClientRateLimiter) allow(clientKey string) bool {
+	now := time.Now()
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.evictLocked(now)
+
+	entry, ok := p.clients[clientKey]
+	if !ok {
+		entry = &clientLimiterEntry{
+			limiter:  rate.NewLimiter(p.limit, p.burst),
+			lastSeen: now,
+		}
+		p.clients[clientKey] = entry
+	}
+
+	entry.lastSeen = now
+	return entry.limiter.Allow()
+}
+
+func (p *perClientRateLimiter) evictLocked(now time.Time) {
+	for key, entry := range p.clients {
+		if now.Sub(entry.lastSeen) > p.idleTTL {
+			delete(p.clients, key)
+		}
+	}
+
+	if len(p.clients) <= p.maxEntries {
+		return
+	}
+
+	// Drop oldest entries when over capacity.
+	for len(p.clients) > p.maxEntries {
+		var oldestKey string
+		var oldestTime time.Time
+		first := true
+		for key, entry := range p.clients {
+			if first || entry.lastSeen.Before(oldestTime) {
+				oldestKey = key
+				oldestTime = entry.lastSeen
+				first = false
+			}
+		}
+		if oldestKey == "" {
+			return
+		}
+		delete(p.clients, oldestKey)
+	}
+}
+
+func (p *perClientRateLimiter) clientCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.clients)
+}
+
+func perClientRateLimitMiddleware(limiter *perClientRateLimiter) gin.HandlerFunc {
+	if limiter == nil {
+		limiter = newPerClientRateLimiter(defaultRequestsPerMinute, defaultRateBurst, defaultClientIdleTTL, defaultMaxClientEntries)
+	}
+
+	return func(c *gin.Context) {
+		clientKey := c.ClientIP()
+		if clientKey == "" {
+			clientKey = "unknown"
+		}
+
+		if !limiter.allow(clientKey) {
+			c.JSON(http.StatusTooManyRequests, gin.H{
+				"error":       "rate limit exceeded",
+				"retry_after": (time.Minute / time.Duration(defaultRequestsPerMinute)).String(),
+			})
+			c.Abort()
+			return
+		}
+		c.Next()
+	}
+}

--- a/go/pkg/api/ratelimit_test.go
+++ b/go/pkg/api/ratelimit_test.go
@@ -26,6 +26,27 @@ func TestPerClientRateLimiter_IsolatesClients(t *testing.T) {
 	}
 }
 
+func TestPerClientRateLimiter_RetryAfterUsesConfiguredRate(t *testing.T) {
+	limiter := newPerClientRateLimiter(120, 2, time.Minute, 128)
+	got := limiter.retryAfter()
+	want := 500 * time.Millisecond
+	if got != want {
+		t.Fatalf("retryAfter() = %v, want %v", got, want)
+	}
+}
+
+func TestPerClientRateLimiter_EnforcesMaxEntries(t *testing.T) {
+	limiter := newPerClientRateLimiter(60, 1, time.Hour, 2)
+
+	limiter.allow("a")
+	limiter.allow("b")
+	limiter.allow("c")
+
+	if limiter.clientCount() > 2 {
+		t.Fatalf("client count = %d, want <= 2", limiter.clientCount())
+	}
+}
+
 func TestPerClientRateLimiter_EvictsIdleClients(t *testing.T) {
 	limiter := newPerClientRateLimiter(60, 1, 10*time.Millisecond, 128)
 

--- a/go/pkg/api/ratelimit_test.go
+++ b/go/pkg/api/ratelimit_test.go
@@ -1,0 +1,46 @@
+package api
+
+import (
+	"testing"
+	"time"
+)
+
+func TestPerClientRateLimiter_IsolatesClients(t *testing.T) {
+	limiter := newPerClientRateLimiter(60, 2, time.Minute, 128)
+
+	if !limiter.allow("client-a") {
+		t.Fatal("client-a first request should be allowed")
+	}
+	if !limiter.allow("client-a") {
+		t.Fatal("client-a second request should be allowed within burst")
+	}
+	if limiter.allow("client-a") {
+		t.Fatal("client-a should be rate limited after burst")
+	}
+
+	if !limiter.allow("client-b") {
+		t.Fatal("client-b first request should be allowed")
+	}
+	if !limiter.allow("client-b") {
+		t.Fatal("client-b second request should be allowed within burst")
+	}
+}
+
+func TestPerClientRateLimiter_EvictsIdleClients(t *testing.T) {
+	limiter := newPerClientRateLimiter(60, 1, 10*time.Millisecond, 128)
+
+	if !limiter.allow("ephemeral") {
+		t.Fatal("expected first request allowed")
+	}
+	if limiter.clientCount() != 1 {
+		t.Fatalf("client count = %d, want 1", limiter.clientCount())
+	}
+
+	time.Sleep(15 * time.Millisecond)
+	if !limiter.allow("other") {
+		t.Fatal("expected other client allowed")
+	}
+	if limiter.clientCount() != 1 {
+		t.Fatalf("expected idle client evicted, count = %d", limiter.clientCount())
+	}
+}

--- a/go/pkg/api/server.go
+++ b/go/pkg/api/server.go
@@ -30,10 +30,11 @@ type Server struct {
 
 // Config holds the server configuration
 type Config struct {
-	Port          int
-	K8sClient     k8s.Client
-	TruenasClient truenas.Client
-	Logger        *zap.Logger
+	Port            int
+	K8sClient       k8s.Client
+	TruenasClient   truenas.Client
+	Logger          *zap.Logger
+	TrustedProxies  []string // empty/nil: do not trust X-Forwarded-For; set for ingress/LB CIDRs
 }
 
 // NewServer creates a new API server with comprehensive middleware
@@ -55,6 +56,11 @@ func NewServer(config Config) (*Server, error) {
 
 	// Create router
 	router := gin.New()
+
+	// Do not trust X-Forwarded-For unless explicit proxy CIDRs are configured.
+	if err := router.SetTrustedProxies(config.TrustedProxies); err != nil {
+		return nil, fmt.Errorf("invalid trusted proxies: %w", err)
+	}
 
 	// Add recovery middleware
 	router.Use(gin.Recovery())

--- a/go/pkg/api/server.go
+++ b/go/pkg/api/server.go
@@ -12,7 +12,6 @@ import (
 	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/orphan"
 	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/truenas"
 	"go.uber.org/zap"
-	"golang.org/x/time/rate"
 )
 
 const (
@@ -69,8 +68,8 @@ func NewServer(config Config) (*Server, error) {
 	// Add logging middleware
 	router.Use(loggingMiddleware(logger))
 
-	// Add rate limiting middleware
-	router.Use(rateLimitMiddleware())
+	// Add per-client rate limiting middleware
+	router.Use(perClientRateLimitMiddleware(nil))
 
 	orphanDetector, err := orphan.NewDetector(config.K8sClient, config.TruenasClient, orphan.Config{
 		AgeThreshold:      defaultOrphanAgeThreshold,
@@ -496,25 +495,3 @@ func requestIDMiddleware() gin.HandlerFunc {
 	}
 }
 
-// rateLimitMiddleware implements rate limiting
-func rateLimitMiddleware() gin.HandlerFunc {
-	// Create a rate limiter: 100 requests per minute
-	limiter := rate.NewLimiter(rate.Every(time.Minute/100), 100)
-
-	return func(c *gin.Context) {
-		if !limiter.Allow() {
-			retryAfter := time.Second
-			if reservation := limiter.Reserve(); reservation.OK() {
-				retryAfter = reservation.Delay()
-				reservation.Cancel()
-			}
-			c.JSON(http.StatusTooManyRequests, gin.H{
-				"error":       "rate limit exceeded",
-				"retry_after": retryAfter.String(),
-			})
-			c.Abort()
-			return
-		}
-		c.Next()
-	}
-}

--- a/go/pkg/k8s/client.go
+++ b/go/pkg/k8s/client.go
@@ -172,10 +172,7 @@ func (c *client) ListPersistentVolumes(ctx context.Context) ([]corev1.Persistent
 	
 	err := retry.OnError(
 		retry.DefaultRetry,
-		func(err error) bool {
-			// Retry on temporary network errors
-			return err != nil
-		},
+		isTransientK8sError,
 		func() error {
 			var err error
 			pvList, err = c.clientset.CoreV1().PersistentVolumes().List(ctx, metav1.ListOptions{})
@@ -207,9 +204,7 @@ func (c *client) ListPersistentVolumeClaims(ctx context.Context, namespace strin
 	
 	err := retry.OnError(
 		retry.DefaultRetry,
-		func(err error) bool {
-			return err != nil
-		},
+		isTransientK8sError,
 		func() error {
 			var err error
 			pvcList, err = c.clientset.CoreV1().PersistentVolumeClaims(namespace).List(ctx, metav1.ListOptions{})
@@ -239,9 +234,7 @@ func (c *client) ListVolumeSnapshots(ctx context.Context, namespace string) ([]s
 	
 	err := retry.OnError(
 		retry.DefaultRetry,
-		func(err error) bool {
-			return err != nil
-		},
+		isTransientK8sError,
 		func() error {
 			var err error
 			snapshotList, err = c.snapshotClient.SnapshotV1().VolumeSnapshots(namespace).List(ctx, metav1.ListOptions{})
@@ -267,9 +260,7 @@ func (c *client) ListStorageClasses(ctx context.Context) ([]storagev1.StorageCla
 	
 	err := retry.OnError(
 		retry.DefaultRetry,
-		func(err error) bool {
-			return err != nil
-		},
+		isTransientK8sError,
 		func() error {
 			var err error
 			scList, err = c.clientset.StorageV1().StorageClasses().List(ctx, metav1.ListOptions{})
@@ -297,9 +288,7 @@ func (c *client) ListPods(ctx context.Context, namespace string) ([]corev1.Pod, 
 	
 	err := retry.OnError(
 		retry.DefaultRetry,
-		func(err error) bool {
-			return err != nil
-		},
+		isTransientK8sError,
 		func() error {
 			var err error
 			podList, err = c.clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
@@ -325,9 +314,7 @@ func (c *client) GetNamespace(ctx context.Context, name string) (*corev1.Namespa
 	
 	err := retry.OnError(
 		retry.DefaultRetry,
-		func(err error) bool {
-			return err != nil
-		},
+		isTransientK8sError,
 		func() error {
 			var err error
 			namespace, err = c.clientset.CoreV1().Namespaces().Get(ctx, name, metav1.GetOptions{})
@@ -351,9 +338,7 @@ func (c *client) GetNamespace(ctx context.Context, name string) (*corev1.Namespa
 func (c *client) TestConnection(ctx context.Context) error {
 	err := retry.OnError(
 		retry.DefaultRetry,
-		func(err error) bool {
-			return err != nil
-		},
+		isTransientK8sError,
 		func() error {
 			_, err := c.clientset.Discovery().ServerVersion()
 			return err
@@ -441,9 +426,7 @@ func (c *client) ListNamespaces(ctx context.Context) ([]corev1.Namespace, error)
 	
 	err := retry.OnError(
 		retry.DefaultRetry,
-		func(err error) bool {
-			return err != nil
-		},
+		isTransientK8sError,
 		func() error {
 			var err error
 			nsList, err = c.clientset.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})

--- a/go/pkg/k8s/retry.go
+++ b/go/pkg/k8s/retry.go
@@ -1,0 +1,41 @@
+package k8s
+
+import (
+	"context"
+	"errors"
+	"net"
+	"os"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+// isTransientK8sError reports whether a Kubernetes API error is worth retrying.
+func isTransientK8sError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	switch {
+	case apierrors.IsTimeout(err),
+		apierrors.IsServerTimeout(err),
+		apierrors.IsTooManyRequests(err),
+		apierrors.IsServiceUnavailable(err),
+		apierrors.IsInternalError(err),
+		apierrors.IsUnexpectedServerError(err):
+		return true
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+
+	if errors.Is(err, os.ErrDeadlineExceeded) {
+		return true
+	}
+
+	return false
+}

--- a/go/pkg/k8s/retry_test.go
+++ b/go/pkg/k8s/retry_test.go
@@ -1,0 +1,47 @@
+package k8s
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestIsTransientK8sError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"not found", apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, "x"), false},
+		{"forbidden", apierrors.NewForbidden(schema.GroupResource{Resource: "pods"}, "x", errors.New("denied")), false},
+		{"timeout", apierrors.NewTimeoutError("slow", 1), true},
+		{"too many requests", apierrors.NewTooManyRequests("slow down", 1), true},
+		{"service unavailable", apierrors.NewServiceUnavailable("unavailable"), true},
+		{"internal error", apierrors.NewInternalError(errors.New("boom")), true},
+		{"context canceled", context.Canceled, false},
+		{"generic error", fmt.Errorf("validation failed"), false},
+		{
+			name: "timeout net error",
+			err: &net.DNSError{
+				Err:       "timeout",
+				IsTimeout: true,
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isTransientK8sError(tt.err)
+			if got != tt.want {
+				t.Fatalf("isTransientK8sError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/go/pkg/monitor/service.go
+++ b/go/pkg/monitor/service.go
@@ -102,9 +102,10 @@ func (s *Service) Start(ctx context.Context) error {
 
 	s.logger.WithComponent("monitor-service").Info("Starting monitoring service")
 
-	// Start metrics exporter
-	if err := s.metricsExporter.Start(); err != nil {
-		return fmt.Errorf("failed to start metrics exporter: %w", err)
+	if s.metricsExporter != nil {
+		if err := s.metricsExporter.Start(); err != nil {
+			return fmt.Errorf("failed to start metrics exporter: %w", err)
+		}
 	}
 
 	s.running = true
@@ -145,8 +146,10 @@ func (s *Service) Stop(ctx context.Context) error {
 		return ctx.Err()
 	}
 
-	// Stop metrics exporter
-	return s.metricsExporter.Stop()
+	if s.metricsExporter != nil {
+		return s.metricsExporter.Stop()
+	}
+	return nil
 }
 
 // GetLastScanResult returns the most recent scan result
@@ -246,6 +249,9 @@ func (s *Service) convertOrphanedResources(orphanResources []orphan.OrphanedReso
 
 // updateMetrics updates Prometheus metrics with scan results
 func (s *Service) updateMetrics(result *ScanResult) {
+	if s.metricsExporter == nil {
+		return
+	}
 	s.metricsExporter.SetOrphanedPVsCount(float64(len(result.OrphanedPVs)))
 	s.metricsExporter.SetOrphanedPVCsCount(float64(len(result.OrphanedPVCs)))
 	s.metricsExporter.SetOrphanedSnapshotsCount(float64(len(result.OrphanedSnapshots)))

--- a/go/pkg/monitor/service_test.go
+++ b/go/pkg/monitor/service_test.go
@@ -1,0 +1,34 @@
+package monitor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/logging"
+)
+
+func TestService_UpdateMetrics_NilExporterDoesNotPanic(t *testing.T) {
+	logger, err := logging.NewLogger(logging.Config{Level: "error", Encoding: "json"})
+	if err != nil {
+		t.Fatalf("logger: %v", err)
+	}
+
+	svc := &Service{
+		logger:          logger,
+		scanInterval:    time.Minute,
+		metricsExporter: nil,
+	}
+
+	svc.updateMetrics(&ScanResult{
+		Timestamp: time.Now(),
+		TotalPVs:  1,
+	})
+}
+
+func TestService_Stop_NilExporterWhenNotRunning(t *testing.T) {
+	svc := &Service{metricsExporter: nil}
+	if err := svc.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Implements [PR 6 — Reliability and Performance Guardrails](docs/superpowers/plans/2026-05-28-repo-health-remediation.md) (M3).

- Per-client API rate limiting (`ClientIP`) with idle TTL eviction and max map size
- Nil-safe monitor metrics exporter paths (Start/Stop/updateMetrics)
- Kubernetes client retries limited to transient API/net errors via `isTransientK8sError`
- Unit tests for limiter fairness/eviction, retry classification, nil exporter

**Spec:** [docs/superpowers/specs/2026-05-28-pr-6-reliability-performance-design.md](docs/superpowers/specs/2026-05-28-pr-6-reliability-performance-design.md)

## Test plan

- [x] `make go-test`
- [x] `make go-lint`

## Mandatory PR checklist

- [x] **Scope:** PR 6 only
- [x] **Correctness:** Tests added for changed behavior
- [x] **Regression Safety:** Full Go test suite green
- [x] **Security:** Rate limits still enforced per client
- [x] **Reliability:** No nil exporter panic; transient-only retries
- [x] **Performance:** Limiter map eviction prevents unbounded growth
- [x] **Docs:** Spec + plan tracking updated
- [x] **Verification Evidence:** `make go-test`, `make go-lint`
- [x] **Tracking:** Plan checkboxes updated; PR URL after open

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced per-client rate limiting to ensure fair request handling.

* **Bug Fixes**
  * Prevented crashes when metrics exporter is absent.
  * Made Kubernetes retries selective to avoid unnecessary retries.

* **Documentation**
  * Updated remediation plan and added a design spec for reliability/performance.

* **Tests**
  * Added tests for rate limiting, Kubernetes retry behavior, and nil metrics exporter handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tomazb/kubernetes-truenas-democratic-tool/pull/56?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->