### PR TITLE
feat(stage2): TTL inventory cache (PR 10)

### DIFF
--- a/config.go.example
+++ b/config.go.example
@@ -29,6 +29,12 @@ metrics:
   port: 8080
   path: /metrics
 
+performance:
+  cache:
+    enabled: true
+    ttl: 5m
+    max_size: 1000
+
 alerts:
   slack:
     webhook: ${SLACK_WEBHOOK}

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -47,6 +47,13 @@ logging:
   format: json
   output: stdout
 
+# In-process inventory cache (wired in Python monitor list operations)
+performance:
+  cache:
+    enabled: true
+    ttl: 5m
+    max_size: 1000
+
 # --- Planned sections below: NOT read by baseline Python library ---
 # Kept as roadmap reference only. See docs/config-compatibility.md.
 

--- a/docs/config-compatibility.md
+++ b/docs/config-compatibility.md
@@ -27,6 +27,7 @@ Go services and the Python library/CLI use **different YAML schemas**. A single 
 | TrueNAS timeout | `truenas.timeout` as duration string (`30s`) | `truenas.timeout` as integer seconds or string with `s` suffix (e.g. `30`, `30s`) |
 | Slack alerts | `alerts.slack.webhook` | `alerts.slack.webhook_url` |
 | Metrics | `metrics.enabled`, `metrics.port`, `metrics.path` — Go monitor exports gauges + histograms | `metrics.enabled` in defaults enables optional Python Prometheus scan metrics; structured phase timing logs always emitted |
+| Inventory cache | `performance.cache.enabled`, `performance.cache.ttl`, `performance.cache.max_size` — **wired** in Go monitor and API | `performance.cache.*` — **wired** in Python clients when `performance.cache.enabled` is true (defaults enable 5m TTL) |
 | Logging | `logging.level`, `logging.encoding` | `logging.level`, `logging.format` in example only |
 | API server listen/TLS | Not in Go config file (CLI flags) | `api:` block in Python example is **planned**, not read today |
 | API auth / security block | `security:` keys parsed in Go config but **not enforced** by shipped API server | Not applicable |
@@ -75,4 +76,4 @@ truenas:
 
 ## Planned sections (Python example only)
 
-Blocks in `config.yaml.example` under `reporting`, `api`, `performance`, and `features` are **roadmap placeholders**. The baseline Python library does not load them. Do not assume they affect runtime behavior.
+Blocks in `config.yaml.example` under `reporting`, `api`, and `features` are **roadmap placeholders**. The baseline Python library does not load them. Do not assume they affect runtime behavior.

--- a/docs/superpowers/plans/2026-05-28-repo-health-remediation.md
+++ b/docs/superpowers/plans/2026-05-28-repo-health-remediation.md
@@ -418,6 +418,7 @@ Suggested worktree layout:
 - **Acceptance criteria:**
   - [x] Cache hit reduces external list call count within TTL window.
   - [x] TTL expiry triggers refresh; tests cover hit/miss/expiry.
+- **PR URL:** https://github.com/tomazb/kubernetes-truenas-democratic-tool/pull/60
 
 #### PR 11: Watch-Based Incremental Reconcile
 

--- a/docs/superpowers/plans/2026-05-28-repo-health-remediation.md
+++ b/docs/superpowers/plans/2026-05-28-repo-health-remediation.md
@@ -97,9 +97,9 @@ Suggested worktree layout:
 
 - **Current phase:** Stage 2 — In Progress (M4 scalability foundation)
 - **Primary owner:** TBD
-- **Last updated:** 2026-05-30
-- **Last merged:** PR 8 documentation accuracy [#58](https://github.com/tomazb/kubernetes-truenas-democratic-tool/pull/58) (2026-05-30)
-- **Next up:** PR 9 — Config wiring + performance observability
+- **Last updated:** 2026-05-31
+- **Last merged:** PR 9 config wiring + performance observability [#59](https://github.com/tomazb/kubernetes-truenas-democratic-tool/pull/59) (2026-05-31, `5829adf`)
+- **Next up:** PR 10 — TTL inventory cache
 
 ## Milestones
 
@@ -377,16 +377,18 @@ Suggested worktree layout:
 - [ ] Introduce incremental/watch-based detection where practical (PR 11).
 - [ ] Add caching/TTL for expensive list operations (PR 10).
 - [ ] Define and track performance budgets (scan time, API p95, memory) (PR 12).
-- [ ] Wire config thresholds and performance observability baseline (PR 9).
+- [x] Wire config thresholds and performance observability baseline (PR 9).
 
 #### PR 9: Config Wiring and Performance Observability
 
-- **Status:** In Progress
+- **Status:** Done
 - **Risk:** Low
 - **Focus:** Wire YAML orphan/snapshot thresholds into Go monitor/API and Python monitor; add Prometheus histograms and Python scan timing.
 - **Branch/worktree:**
   - Branch: `feature/pr-9-config-perf-observability`
-  - Worktree: `.worktrees/pr-9-config-perf-observability`
+  - Worktree: `.worktrees/pr-9-config-perf-observability` (removed)
+- **Merged:** 2026-05-31
+- **Merge commit:** `5829adf`
 - **Spec/design:** `docs/superpowers/specs/2026-05-30-pr-9-config-perf-observability-design.md`
 - **Implementation plan:** `docs/superpowers/plans/2026-05-30-pr-9-config-perf-observability.md`
 - **Files (expected):**
@@ -404,16 +406,18 @@ Suggested worktree layout:
 
 #### PR 10: TTL Inventory Cache
 
-- **Status:** Planned
+- **Status:** In Progress
 - **Risk:** Medium
 - **Focus:** In-process TTL cache for expensive K8s/TrueNAS list operations; dedupe duplicate PVC lists in detector.
 - **Branch/worktree:**
   - Branch: `feature/pr-10-inventory-cache`
   - Worktree: `.worktrees/pr-10-inventory-cache`
+- **Spec/design:** `docs/superpowers/specs/2026-05-31-pr-10-inventory-cache-design.md`
+- **Implementation plan:** `docs/superpowers/plans/2026-05-31-pr-10-inventory-cache.md`
 - **Depends on:** PR 9 (metrics baseline)
 - **Acceptance criteria:**
-  - [ ] Cache hit reduces external list call count within TTL window.
-  - [ ] TTL expiry triggers refresh; tests cover hit/miss/expiry.
+  - [x] Cache hit reduces external list call count within TTL window.
+  - [x] TTL expiry triggers refresh; tests cover hit/miss/expiry.
 
 #### PR 11: Watch-Based Incremental Reconcile
 
@@ -468,7 +472,7 @@ Suggested worktree layout:
 - [x] Complete PR 7 (CI trust).
 - [x] Complete PR 8 (docs accuracy).
 - [x] Start Stage 2+ initiatives after baseline PRs are merged.
-- [ ] Complete PR 9 (config wiring + performance observability).
+- [x] Complete PR 9 (config wiring + performance observability).
 - [ ] Complete PR 10 (TTL inventory cache).
 - [ ] Complete PR 11 (watch/incremental reconcile).
 - [ ] Complete PR 12 (performance budgets).

--- a/docs/superpowers/plans/2026-05-31-pr-10-inventory-cache.md
+++ b/docs/superpowers/plans/2026-05-31-pr-10-inventory-cache.md
@@ -1,0 +1,92 @@
+# PR 10: TTL Inventory Cache — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add in-process TTL cache for expensive K8s/TrueNAS list operations and eliminate duplicate Go PVC listing.
+
+**Architecture:** Generic TTL store in `go/pkg/inventorycache/` with caching client decorators; Python parity via `inventory_cache.py`; config wired in both stacks.
+
+**Tech Stack:** Go 1.24+, Python 3.10+, Prometheus client libraries.
+
+**Spec:** [2026-05-31-pr-10-inventory-cache-design.md](../specs/2026-05-31-pr-10-inventory-cache-design.md)
+
+---
+
+## Task 1: Go TTL cache package (TDD)
+
+**Files:** `go/pkg/inventorycache/cache.go`, `cache_test.go`
+
+- [ ] Write failing tests: hit, miss, expiry, max_size eviction, disabled passthrough
+- [ ] Implement thread-safe TTL cache with injectable `now func() time.Time`
+- [ ] Run `go test ./pkg/inventorycache/... -v`
+
+## Task 2: Go caching client wrappers
+
+**Files:** `go/pkg/inventorycache/cached_k8s.go`, `cached_truenas.go`, `*_test.go`
+
+- [ ] Wrap list methods only; passthrough for health/RBAC/other ops
+- [ ] Cache keys per spec (`k8s_pvs`, `k8s_pvcs:<ns>`, etc.)
+- [ ] Test: two calls within TTL → one upstream invocation
+
+## Task 3: Go config wiring
+
+**Files:** `go/pkg/config/config.go`, `config.go.example`, defaults
+
+- [ ] Add `PerformanceConfig` with `CacheConfig` (`enabled`, `ttl`, `max_size`)
+- [ ] Defaults: enabled=true, ttl=5m, max_size=1000
+- [ ] Config tests for parsing
+
+## Task 4: Go PVC dedupe
+
+**Files:** `go/pkg/orphan/detector.go`, `detector_test.go`
+
+- [ ] Refactor `detectOrphanedPVCs` to single `ListPersistentVolumeClaims` + local Pending filter
+- [ ] Test: mock client call count = 1 for PVC detection path
+
+## Task 5: Go metrics
+
+**Files:** `go/pkg/metrics/exporter.go`, `exporter_test.go`
+
+- [ ] Add `truenas_monitor_inventory_cache_hits_total` and `_misses_total` with `operation` label
+- [ ] Wire cache stats callback from inventorycache wrappers
+
+## Task 6: Go integration
+
+**Files:** `go/cmd/monitor/main.go`, `go/cmd/api-server/main.go`
+
+- [ ] Wrap k8s/truenas clients with caching decorators when cache enabled
+- [ ] Pass metrics exporter for hit/miss recording
+
+## Task 7: Python inventory cache
+
+**Files:** `python/truenas_storage_monitor/inventory_cache.py`, `config.py`, `k8s_client.py`, `truenas_client.py`
+
+- [ ] TTL cache module with max_size
+- [ ] Config properties: `cache_enabled`, `cache_ttl`, `cache_max_size`
+- [ ] Wrap list methods on clients
+
+## Task 8: Python tests
+
+**Files:** `python/tests/unit/test_inventory_cache.py`
+
+- [ ] hit/miss/expiry/disabled tests
+- [ ] Monitor integration smoke test
+
+## Task 9: Docs
+
+**Files:** `docs/config-compatibility.md`, `config.go.example`, `config.yaml.example`
+
+- [ ] Document wired cache keys for Go and Python
+- [ ] Note in-process L1 only; Redis remains planned
+
+## Task 10: Verification
+
+```bash
+cd go && go test ./pkg/inventorycache/... ./pkg/orphan/... ./pkg/config/... ./pkg/metrics/... -v
+cd python && pytest tests/unit/test_inventory_cache.py tests/unit/test_monitor.py -v
+make go-test && make python-test
+make go-lint && make python-lint
+```
+
+- [ ] Code review before commit and push
+- [ ] Update remediation plan with PR URL

--- a/docs/superpowers/specs/2026-05-31-pr-10-inventory-cache-design.md
+++ b/docs/superpowers/specs/2026-05-31-pr-10-inventory-cache-design.md
@@ -1,0 +1,115 @@
+# PR 10: TTL Inventory Cache — Design Spec
+
+**Date:** 2026-05-31  
+**Plan item:** [Remediation plan PR 10](../plans/2026-05-28-repo-health-remediation.md)  
+**Milestone:** M4 — Scale and Product Depth (Stage 2 foundation)
+
+## Problem statement and scope
+
+Every orphan scan re-lists all K8s PVs/PVCs/snapshots and TrueNAS datasets/snapshots. On large clusters this is O(n) API traffic per scan interval with no reuse between consecutive monitor scans or rapid API orphan requests.
+
+**Known duplicate today (Go):** `detectOrphanedPVCs` calls both `ListUnboundPersistentVolumeClaims` and `ListPersistentVolumeClaims`, but unbound already re-lists all PVCs internally in `go/pkg/k8s/client.go`.
+
+Python already lists PVCs once in `find_orphaned_resources()` — no dedupe needed there.
+
+PR 9 delivered phase histograms and scan timing needed to validate cache effectiveness.
+
+**In scope:**
+
+- In-process, thread-safe TTL cache for list inventory operations (Go + Python)
+- Config keys wired: `enabled`, `ttl`, `max_size`
+- Cache hit/miss metrics (Go; optional Python when `metrics.enabled`)
+- Go PVC dedupe: single list + in-memory unbound filter in detector
+- Tests: hit, miss, expiry, disabled cache passthrough
+- Docs: `config-compatibility.md`, `config.go.example`
+
+**Out of scope:**
+
+- Redis/shared cache (ARCHITECTURE target-state only)
+- Watch/incremental reconcile (PR 11)
+- Performance budget enforcement (PR 12)
+- Caching mutating operations or per-object reads
+
+## Current vs target behavior
+
+| Surface | Current | Target |
+|---------|---------|--------|
+| Go monitor/API list calls | Every scan hits K8s + TrueNAS APIs | Cached within TTL; zero upstream calls on hit |
+| Go PVC orphan detection | Two PVC list calls per scan | One PVC list; unbound filtered in memory |
+| Go config cache keys | Not present | `performance.cache.enabled/ttl/max_size` wired |
+| Python list calls | Every scan hits APIs | Cached when `performance.cache.enabled` |
+| Python cache config | Defaults exist but unused | Wired from config |
+| Metrics | List phase histograms only | Add cache hit/miss counters by operation |
+
+## Technical approach
+
+### Cache keys
+
+| Operation | Cache key | Notes |
+|-----------|-----------|-------|
+| K8s democratic PVs | `k8s_pvs` | cluster-scoped |
+| K8s PVCs | `k8s_pvcs:<namespace\|*>` | empty namespace = all namespaces |
+| K8s VolumeSnapshots | `k8s_snapshots:<namespace\|*>` | |
+| TrueNAS volumes | `truenas_datasets` | |
+| TrueNAS snapshots | `truenas_snapshots` | |
+
+Default TTL: **5m**. Default **enabled: true**.
+
+### Go architecture
+
+1. New package `go/pkg/inventorycache/` — generic TTL store with max size and injectable clock for tests.
+2. `CachedK8sClient` / `CachedTrueNASClient` decorators implementing existing `k8s.Client` and `truenas.Client` interfaces; cache only list inventory methods.
+3. Wire in `go/cmd/monitor/main.go` and `go/cmd/api-server/main.go` after `config.Load`.
+4. Refactor `detectOrphanedPVCs` to list once and filter Pending locally.
+5. Add Prometheus counters `truenas_monitor_inventory_cache_hits_total` and `_misses_total` with fixed `operation` label.
+
+### Python architecture
+
+1. New `python/truenas_storage_monitor/inventory_cache.py` — TTL dict with max size.
+2. Wrap list methods on k8s/truenas clients or inject cache at client construction.
+3. Wire `performance.cache.*` from config (properties on `Config`).
+
+### Alternatives considered
+
+| Approach | Verdict |
+|----------|---------|
+| Cache only inside detector | Rejected — API direct list handlers would miss cache |
+| Cache inside raw k8s client | Rejected — couples client to cache lifecycle |
+| External Redis | Out of scope for PR 10 |
+
+## Risk, failure modes, and mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Stale inventory within TTL | Document TTL tradeoff; PR 11 watch mode addresses freshness |
+| Memory growth from large lists | `max_size` cap with LRU-style eviction |
+| Cache key collision across namespaces | Namespace included in PVC/snapshot keys |
+| Disabled cache misconfiguration | Passthrough to underlying client when `enabled: false` |
+| Thread safety under concurrent API requests | Mutex-protected cache store |
+
+## Test strategy
+
+```bash
+cd go && go test ./pkg/inventorycache/... ./pkg/orphan/... ./pkg/k8s/... ./pkg/metrics/... -v
+cd python && pytest tests/unit/test_inventory_cache.py tests/unit/test_monitor.py -v
+make go-test && make python-test
+make go-lint && make python-lint
+```
+
+**Go tests:**
+
+- TTL cache hit/miss/expiry/max_size with fake clock
+- Caching client wrapper reduces upstream call count (2 scans within TTL → 1 call)
+- Detector PVC test proves single `ListPersistentVolumeClaims` invocation
+- Exporter observes hit/miss counters
+
+**Python tests:**
+
+- Cache hit/miss/expiry/disabled unit tests
+- Monitor scan uses cache when enabled
+
+## Rollout and backout
+
+**Rollout:** Deploy with cache enabled by default (5m TTL). Metrics show hit ratio on `/metrics`.
+
+**Backout:** Set `performance.cache.enabled: false` or revert PR; restores direct list behavior with no schema migration.

--- a/go/cmd/api-server/main.go
+++ b/go/cmd/api-server/main.go
@@ -11,7 +11,9 @@ import (
 
 	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/api"
 	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/config"
+	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/inventorycache"
 	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/k8s"
+	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/metrics"
 	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/truenas"
 	"go.uber.org/zap"
 )
@@ -77,6 +79,15 @@ func main() {
 	if err != nil {
 		logger.Fatal("Failed to initialize TrueNAS client", zap.Error(err))
 	}
+
+	metricsExporter := metrics.NewExporter(metrics.Config{
+		Enabled: cfg.Metrics.Enabled,
+		Port:    cfg.Metrics.Port,
+		Path:    cfg.Metrics.Path,
+	})
+	inventoryCache := inventorycache.NewFromConfig(cfg.Performance, metricsExporter)
+	k8sClient = inventorycache.WrapK8sClient(k8sClient, inventoryCache)
+	truenasClient = inventorycache.WrapTrueNASClient(truenasClient, inventoryCache)
 
 	// Initialize API server
 	apiServer, err := api.NewServer(api.Config{

--- a/go/cmd/api-server/main.go
+++ b/go/cmd/api-server/main.go
@@ -85,6 +85,11 @@ func main() {
 		Port:    cfg.Metrics.Port,
 		Path:    cfg.Metrics.Path,
 	})
+	if cfg.Metrics.Enabled {
+		if err := metricsExporter.Start(); err != nil {
+			logger.Fatal("Failed to start metrics exporter", zap.Error(err))
+		}
+	}
 	inventoryCache := inventorycache.NewFromConfig(cfg.Performance, metricsExporter)
 	k8sClient = inventorycache.WrapK8sClient(k8sClient, inventoryCache)
 	truenasClient = inventorycache.WrapTrueNASClient(truenasClient, inventoryCache)
@@ -128,6 +133,12 @@ func main() {
 	if err := apiServer.Stop(shutdownCtx); err != nil {
 		logger.Error("Error during shutdown", zap.Error(err))
 		os.Exit(1)
+	}
+
+	if cfg.Metrics.Enabled {
+		if err := metricsExporter.Stop(); err != nil {
+			logger.Error("Error stopping metrics exporter", zap.Error(err))
+		}
 	}
 
 	logger.Info("API server stopped successfully")

--- a/go/cmd/monitor/main.go
+++ b/go/cmd/monitor/main.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/config"
+	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/inventorycache"
 	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/k8s"
 	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/logging"
 	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/metrics"
@@ -85,6 +86,10 @@ func main() {
 		Port:    cfg.Metrics.Port,
 		Path:    cfg.Metrics.Path,
 	})
+
+	inventoryCache := inventorycache.NewFromConfig(cfg.Performance, metricsExporter)
+	k8sClient = inventorycache.WrapK8sClient(k8sClient, inventoryCache)
+	truenasClient = inventorycache.WrapTrueNASClient(truenasClient, inventoryCache)
 
 	// Initialize monitor service
 	monitorService, err := monitor.NewService(monitor.Config{

--- a/go/pkg/config/config.go
+++ b/go/pkg/config/config.go
@@ -149,6 +149,10 @@ func Load(path string) (*Config, error) {
 		if err := yaml.Unmarshal([]byte(expanded), config); err != nil {
 			return nil, fmt.Errorf("failed to parse config file: %w", err)
 		}
+
+		if err := config.validatePerformanceCache(); err != nil {
+			return nil, fmt.Errorf("invalid configuration: %w", err)
+		}
 	}
 
 	config.applyPerformanceDefaults()
@@ -161,6 +165,16 @@ func Load(path string) (*Config, error) {
 	}
 
 	return config, nil
+}
+
+func (c *Config) validatePerformanceCache() error {
+	if c.Performance.Cache.TTL != 0 && c.Performance.Cache.TTL < time.Second {
+		return fmt.Errorf("performance.cache.ttl must be at least 1 second")
+	}
+	if c.Performance.Cache.MaxSize < 0 {
+		return fmt.Errorf("performance.cache.max_size must be at least 1")
+	}
+	return nil
 }
 
 func (c *Config) applyPerformanceDefaults() {
@@ -201,8 +215,6 @@ func expandEnvVars(input string) string {
 
 // validate checks if the configuration is valid
 func (c *Config) validate() error {
-	c.applyPerformanceDefaults()
-
 	// TrueNAS validation
 	if c.TrueNAS.URL == "" {
 		return fmt.Errorf("truenas.url is required")

--- a/go/pkg/config/config.go
+++ b/go/pkg/config/config.go
@@ -12,13 +12,14 @@ import (
 
 // Config represents the application configuration
 type Config struct {
-	Kubernetes KubernetesConfig `yaml:"kubernetes"`
-	TrueNAS    TrueNASConfig    `yaml:"truenas"`
-	Monitor    MonitorConfig    `yaml:"monitor"`
-	Metrics    MetricsConfig    `yaml:"metrics"`
-	Alerts     AlertsConfig     `yaml:"alerts"`
-	Logging    LoggingConfig    `yaml:"logging"`
-	Security   SecurityConfig   `yaml:"security"`
+	Kubernetes  KubernetesConfig  `yaml:"kubernetes"`
+	TrueNAS     TrueNASConfig     `yaml:"truenas"`
+	Monitor     MonitorConfig     `yaml:"monitor"`
+	Metrics     MetricsConfig     `yaml:"metrics"`
+	Performance PerformanceConfig `yaml:"performance"`
+	Alerts      AlertsConfig      `yaml:"alerts"`
+	Logging     LoggingConfig     `yaml:"logging"`
+	Security    SecurityConfig    `yaml:"security"`
 }
 
 // KubernetesConfig holds Kubernetes connection settings
@@ -50,6 +51,18 @@ type MetricsConfig struct {
 	Enabled bool   `yaml:"enabled"`
 	Port    int    `yaml:"port"`
 	Path    string `yaml:"path"`
+}
+
+// PerformanceConfig holds performance tuning settings.
+type PerformanceConfig struct {
+	Cache CacheConfig `yaml:"cache"`
+}
+
+// CacheConfig holds in-process inventory cache settings.
+type CacheConfig struct {
+	Enabled bool          `yaml:"enabled"`
+	TTL     time.Duration `yaml:"ttl"`
+	MaxSize int           `yaml:"max_size"`
 }
 
 // AlertsConfig holds alerting settings
@@ -100,6 +113,13 @@ func Load(path string) (*Config, error) {
 			Port:    8080,
 			Path:    "/metrics",
 		},
+		Performance: PerformanceConfig{
+			Cache: CacheConfig{
+				Enabled: true,
+				TTL:     5 * time.Minute,
+				MaxSize: 1000,
+			},
+		},
 		Logging: LoggingConfig{
 			Level:       "info",
 			Development: false,
@@ -131,6 +151,8 @@ func Load(path string) (*Config, error) {
 		}
 	}
 
+	config.applyPerformanceDefaults()
+
 	// Validate configuration only if file exists
 	if fileExists {
 		if err := config.validate(); err != nil {
@@ -139,6 +161,15 @@ func Load(path string) (*Config, error) {
 	}
 
 	return config, nil
+}
+
+func (c *Config) applyPerformanceDefaults() {
+	if c.Performance.Cache.TTL == 0 {
+		c.Performance.Cache.TTL = 5 * time.Minute
+	}
+	if c.Performance.Cache.MaxSize == 0 {
+		c.Performance.Cache.MaxSize = 1000
+	}
 }
 
 // expandEnvVars expands environment variables in the format ${VAR_NAME} or ${VAR_NAME:default}
@@ -170,6 +201,8 @@ func expandEnvVars(input string) string {
 
 // validate checks if the configuration is valid
 func (c *Config) validate() error {
+	c.applyPerformanceDefaults()
+
 	// TrueNAS validation
 	if c.TrueNAS.URL == "" {
 		return fmt.Errorf("truenas.url is required")
@@ -218,6 +251,14 @@ func (c *Config) validate() error {
 
 	if c.Metrics.Path == "" {
 		return fmt.Errorf("metrics.path cannot be empty")
+	}
+
+	if c.Performance.Cache.TTL < time.Second {
+		return fmt.Errorf("performance.cache.ttl must be at least 1 second")
+	}
+
+	if c.Performance.Cache.Enabled && c.Performance.Cache.MaxSize < 1 {
+		return fmt.Errorf("performance.cache.max_size must be at least 1")
 	}
 
 	// Logging validation

--- a/go/pkg/config/config_test.go
+++ b/go/pkg/config/config_test.go
@@ -231,8 +231,91 @@ func TestValidate(t *testing.T) {
 					AllowedOrigins: []string{"*"},
 					SessionTimeout: 24 * time.Hour,
 				},
+				Performance: PerformanceConfig{
+					Cache: CacheConfig{
+						Enabled: true,
+						TTL:     5 * time.Minute,
+						MaxSize: 1000,
+					},
+				},
 			},
 			wantErr: false,
+		},
+		{
+			name: "cache ttl too short",
+			config: &Config{
+				TrueNAS: TrueNASConfig{
+					URL:      "https://truenas.example.com",
+					Username: "admin",
+					Password: "secret123",
+					Timeout:  "30s",
+				},
+				Monitor: MonitorConfig{
+					ScanInterval:    5 * time.Minute,
+					OrphanThreshold: 24 * time.Hour,
+				},
+				Metrics: MetricsConfig{
+					Port: 8080,
+					Path: "/metrics",
+				},
+				Logging: LoggingConfig{
+					Level:    "info",
+					Encoding: "json",
+				},
+				Security: SecurityConfig{
+					TLSMinVersion:  "1.3",
+					RateLimitRPS:   100,
+					AllowedOrigins: []string{"*"},
+					SessionTimeout: 24 * time.Hour,
+				},
+				Performance: PerformanceConfig{
+					Cache: CacheConfig{
+						Enabled: true,
+						TTL:     500 * time.Millisecond,
+						MaxSize: 1000,
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "performance.cache.ttl must be at least 1 second",
+		},
+		{
+			name: "cache max size invalid when enabled",
+			config: &Config{
+				TrueNAS: TrueNASConfig{
+					URL:      "https://truenas.example.com",
+					Username: "admin",
+					Password: "secret123",
+					Timeout:  "30s",
+				},
+				Monitor: MonitorConfig{
+					ScanInterval:    5 * time.Minute,
+					OrphanThreshold: 24 * time.Hour,
+				},
+				Metrics: MetricsConfig{
+					Port: 8080,
+					Path: "/metrics",
+				},
+				Logging: LoggingConfig{
+					Level:    "info",
+					Encoding: "json",
+				},
+				Security: SecurityConfig{
+					TLSMinVersion:  "1.3",
+					RateLimitRPS:   100,
+					AllowedOrigins: []string{"*"},
+					SessionTimeout: 24 * time.Hour,
+				},
+				Performance: PerformanceConfig{
+					Cache: CacheConfig{
+						Enabled: true,
+						TTL:     5 * time.Minute,
+						MaxSize: -1,
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "performance.cache.max_size must be at least 1",
 		},
 		{
 			name: "missing TrueNAS URL",
@@ -397,7 +480,29 @@ func TestValidate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.config.validate()
+			cfg := tt.config
+			if tt.name == "cache ttl too short" {
+				err := cfg.validatePerformanceCache()
+				if tt.wantErr {
+					assert.Error(t, err)
+					if tt.errMsg != "" {
+						assert.Contains(t, err.Error(), tt.errMsg)
+					}
+				} else {
+					assert.NoError(t, err)
+				}
+				return
+			}
+
+			if tt.name == "cache max size invalid when enabled" {
+				err := cfg.validatePerformanceCache()
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+				return
+			}
+
+			cfg.applyPerformanceDefaults()
+			err := cfg.validate()
 
 			if tt.wantErr {
 				assert.Error(t, err)

--- a/go/pkg/config/config_test.go
+++ b/go/pkg/config/config_test.go
@@ -538,6 +538,13 @@ func validConfigForValidate(t *testing.T) *Config {
 			AllowedOrigins: []string{"*"},
 			SessionTimeout: 24 * time.Hour,
 		},
+		Performance: PerformanceConfig{
+			Cache: CacheConfig{
+				Enabled: true,
+				TTL:     5 * time.Minute,
+				MaxSize: 1000,
+			},
+		},
 	}
 }
 

--- a/go/pkg/inventorycache/cache.go
+++ b/go/pkg/inventorycache/cache.go
@@ -1,0 +1,150 @@
+package inventorycache
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// StatsRecorder records cache hit/miss events for metrics.
+type StatsRecorder func(operation string, hit bool)
+
+// Config holds TTL cache settings.
+type Config struct {
+	Enabled bool
+	TTL     time.Duration
+	MaxSize int
+	Now     func() time.Time
+	Stats   StatsRecorder
+}
+
+// Cache is a thread-safe in-memory TTL cache with optional max size.
+type Cache struct {
+	enabled bool
+	ttl     time.Duration
+	maxSize int
+	now     func() time.Time
+	stats   StatsRecorder
+
+	mu      sync.Mutex
+	entries map[string]entry
+}
+
+type entry struct {
+	value      any
+	expiresAt  time.Time
+	insertedAt time.Time
+}
+
+// NewCache creates a TTL cache. When disabled, GetOrLoad always calls the loader.
+func NewCache(cfg Config) *Cache {
+	now := cfg.Now
+	if now == nil {
+		now = time.Now
+	}
+	maxSize := cfg.MaxSize
+	if maxSize <= 0 {
+		maxSize = 1000
+	}
+	ttl := cfg.TTL
+	if ttl <= 0 {
+		ttl = 5 * time.Minute
+	}
+
+	return &Cache{
+		enabled: cfg.Enabled,
+		ttl:     ttl,
+		maxSize: maxSize,
+		now:     now,
+		stats:   cfg.Stats,
+		entries: make(map[string]entry),
+	}
+}
+
+// Enabled reports whether caching is active.
+func (c *Cache) Enabled() bool {
+	return c != nil && c.enabled
+}
+
+// GetOrLoad returns a cached value or loads it via loader when missing or expired.
+func GetOrLoad[T any](c *Cache, operation, key string, loader func() (T, error)) (T, error) {
+	var zero T
+	if c == nil || !c.enabled {
+		return loader()
+	}
+
+	if value, ok := c.get(operation, key); ok {
+		typed, ok := value.(T)
+		if !ok {
+			return zero, fmt.Errorf("inventory cache type mismatch for key %q", key)
+		}
+		return typed, nil
+	}
+
+	loaded, err := loader()
+	if err != nil {
+		return zero, err
+	}
+
+	c.set(key, loaded)
+	if c.stats != nil {
+		c.stats(operation, false)
+	}
+	return loaded, nil
+}
+
+func (c *Cache) get(operation, key string) (any, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	item, ok := c.entries[key]
+	if !ok {
+		return nil, false
+	}
+
+	if c.now().After(item.expiresAt) {
+		delete(c.entries, key)
+		return nil, false
+	}
+
+	if c.stats != nil {
+		c.stats(operation, true)
+	}
+	return item.value, true
+}
+
+func (c *Cache) set(key string, value any) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := c.now()
+	c.entries[key] = entry{
+		value:      value,
+		expiresAt:  now.Add(c.ttl),
+		insertedAt: now,
+	}
+
+	if len(c.entries) <= c.maxSize {
+		return
+	}
+
+	var oldestKey string
+	var oldestTime time.Time
+	for k, item := range c.entries {
+		if oldestKey == "" || item.insertedAt.Before(oldestTime) {
+			oldestKey = k
+			oldestTime = item.insertedAt
+		}
+	}
+	if oldestKey != "" {
+		delete(c.entries, oldestKey)
+	}
+}
+
+// NamespaceKey builds a cache key with optional namespace scope.
+func NamespaceKey(prefix, namespace string) string {
+	if namespace == "" {
+		return prefix + ":*"
+	}
+	return prefix + ":" + namespace
+}

--- a/go/pkg/inventorycache/cache.go
+++ b/go/pkg/inventorycache/cache.go
@@ -73,10 +73,13 @@ func GetOrLoad[T any](c *Cache, operation, key string, loader func() (T, error))
 		return loader()
 	}
 
-	if value, ok := c.get(operation, key); ok {
+	if value, ok := c.get(key); ok {
 		typed, ok := value.(T)
 		if !ok {
 			return zero, fmt.Errorf("inventory cache type mismatch for key %q", key)
+		}
+		if c.stats != nil {
+			c.stats(operation, true)
 		}
 		return typed, nil
 	}
@@ -93,7 +96,7 @@ func GetOrLoad[T any](c *Cache, operation, key string, loader func() (T, error))
 	return loaded, nil
 }
 
-func (c *Cache) get(operation, key string) (any, bool) {
+func (c *Cache) get(key string) (any, bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -102,14 +105,11 @@ func (c *Cache) get(operation, key string) (any, bool) {
 		return nil, false
 	}
 
-	if c.now().After(item.expiresAt) {
+	if !c.now().Before(item.expiresAt) {
 		delete(c.entries, key)
 		return nil, false
 	}
 
-	if c.stats != nil {
-		c.stats(operation, true)
-	}
 	return item.value, true
 }
 

--- a/go/pkg/inventorycache/cache_test.go
+++ b/go/pkg/inventorycache/cache_test.go
@@ -1,0 +1,119 @@
+package inventorycache
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCache_GetOrLoad_HitAndMiss(t *testing.T) {
+	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
+	var hits, misses int64
+
+	cache := NewCache(Config{
+		Enabled: true,
+		TTL:     time.Minute,
+		MaxSize: 10,
+		Now:     func() time.Time { return now },
+		Stats: func(_ string, hit bool) {
+			if hit {
+				atomic.AddInt64(&hits, 1)
+			} else {
+				atomic.AddInt64(&misses, 1)
+			}
+		},
+	})
+
+	var loads int32
+	loader := func() (string, error) {
+		atomic.AddInt32(&loads, 1)
+		return "value", nil
+	}
+
+	v1, err := GetOrLoad(cache, "k8s_pvs", "k8s_pvs", loader)
+	require.NoError(t, err)
+	require.Equal(t, "value", v1)
+	require.Equal(t, int32(1), loads)
+	require.Equal(t, int64(0), hits)
+	require.Equal(t, int64(1), misses)
+
+	v2, err := GetOrLoad(cache, "k8s_pvs", "k8s_pvs", loader)
+	require.NoError(t, err)
+	require.Equal(t, "value", v2)
+	require.Equal(t, int32(1), loads)
+	require.Equal(t, int64(1), hits)
+	require.Equal(t, int64(1), misses)
+}
+
+func TestCache_GetOrLoad_Expiry(t *testing.T) {
+	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
+	cache := NewCache(Config{
+		Enabled: true,
+		TTL:     time.Minute,
+		MaxSize: 10,
+		Now:     func() time.Time { return now },
+	})
+
+	var loads int32
+	loader := func() (int, error) {
+		atomic.AddInt32(&loads, 1)
+		return 1, nil
+	}
+
+	_, err := GetOrLoad(cache, "k8s_pvs", "k8s_pvs", loader)
+	require.NoError(t, err)
+
+	now = now.Add(2 * time.Minute)
+
+	_, err = GetOrLoad(cache, "k8s_pvs", "k8s_pvs", loader)
+	require.NoError(t, err)
+	require.Equal(t, int32(2), loads)
+}
+
+func TestCache_GetOrLoad_MaxSizeEviction(t *testing.T) {
+	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
+	cache := NewCache(Config{
+		Enabled: true,
+		TTL:     time.Hour,
+		MaxSize: 2,
+		Now:     func() time.Time { return now },
+	})
+
+	_, err := GetOrLoad(cache, "op", "key1", func() (string, error) { return "a", nil })
+	require.NoError(t, err)
+	now = now.Add(time.Second)
+	_, err = GetOrLoad(cache, "op", "key2", func() (string, error) { return "b", nil })
+	require.NoError(t, err)
+	now = now.Add(time.Second)
+	_, err = GetOrLoad(cache, "op", "key3", func() (string, error) { return "c", nil })
+	require.NoError(t, err)
+
+	cache.mu.Lock()
+	require.Len(t, cache.entries, 2)
+	_, hasKey1 := cache.entries["key1"]
+	cache.mu.Unlock()
+	require.False(t, hasKey1, "oldest entry should be evicted")
+}
+
+func TestCache_DisabledPassthrough(t *testing.T) {
+	cache := NewCache(Config{Enabled: false})
+
+	var loads int32
+	loader := func() (string, error) {
+		atomic.AddInt32(&loads, 1)
+		return "direct", nil
+	}
+
+	_, err := GetOrLoad(cache, "k8s_pvs", "k8s_pvs", loader)
+	require.NoError(t, err)
+	_, err = GetOrLoad(cache, "k8s_pvs", "k8s_pvs", loader)
+	require.NoError(t, err)
+	require.Equal(t, int32(2), loads)
+}
+
+func TestNamespaceKey(t *testing.T) {
+	require.Equal(t, "k8s_pvcs:*", NamespaceKey("k8s_pvcs", ""))
+	require.Equal(t, "k8s_pvcs:apps", NamespaceKey("k8s_pvcs", "apps"))
+}

--- a/go/pkg/inventorycache/cached_clients_test.go
+++ b/go/pkg/inventorycache/cached_clients_test.go
@@ -1,0 +1,153 @@
+package inventorycache
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
+	"github.com/stretchr/testify/require"
+	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/k8s"
+	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/truenas"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type countingK8sClient struct {
+	pvcCalls int32
+	pvCalls  int32
+}
+
+func (c *countingK8sClient) ListPersistentVolumes(context.Context) ([]corev1.PersistentVolume, error) {
+	atomic.AddInt32(&c.pvCalls, 1)
+	return []corev1.PersistentVolume{{ObjectMeta: metav1.ObjectMeta{Name: "pv-1"}}}, nil
+}
+
+func (c *countingK8sClient) ListPersistentVolumeClaims(context.Context, string) ([]corev1.PersistentVolumeClaim, error) {
+	atomic.AddInt32(&c.pvcCalls, 1)
+	return []corev1.PersistentVolumeClaim{{ObjectMeta: metav1.ObjectMeta{Name: "pvc-1"}}}, nil
+}
+
+func (c *countingK8sClient) ListVolumeSnapshots(context.Context, string) ([]snapshotv1.VolumeSnapshot, error) {
+	return nil, nil
+}
+
+func (c *countingK8sClient) ListStorageClasses(context.Context) ([]storagev1.StorageClass, error) {
+	return nil, nil
+}
+
+func (c *countingK8sClient) ListPods(context.Context, string) ([]corev1.Pod, error) {
+	return nil, nil
+}
+
+func (c *countingK8sClient) ListNamespaces(context.Context) ([]corev1.Namespace, error) {
+	return nil, nil
+}
+
+func (c *countingK8sClient) GetNamespace(context.Context, string) (*corev1.Namespace, error) {
+	return nil, nil
+}
+
+func (c *countingK8sClient) ListPersistentVolumesByStorageClass(context.Context, string) ([]corev1.PersistentVolume, error) {
+	return nil, nil
+}
+
+func (c *countingK8sClient) ListPersistentVolumeClaimsByStorageClass(context.Context, string, string) ([]corev1.PersistentVolumeClaim, error) {
+	return nil, nil
+}
+
+func (c *countingK8sClient) ListDemocraticCSIPersistentVolumes(context.Context) ([]corev1.PersistentVolume, error) {
+	return nil, nil
+}
+
+func (c *countingK8sClient) ListUnboundPersistentVolumeClaims(context.Context, string) ([]corev1.PersistentVolumeClaim, error) {
+	return nil, nil
+}
+
+func (c *countingK8sClient) TestConnection(context.Context) error { return nil }
+
+func (c *countingK8sClient) ValidateRBACPermissions(context.Context) (*k8s.RBACValidationResult, error) {
+	return nil, nil
+}
+
+func (c *countingK8sClient) GetClusterInfo(context.Context) (*k8s.ClusterInfo, error) {
+	return nil, nil
+}
+
+func (c *countingK8sClient) ListCSINodes(context.Context) ([]storagev1.CSINode, error) {
+	return nil, nil
+}
+
+func (c *countingK8sClient) ListCSIDrivers(context.Context) ([]storagev1.CSIDriver, error) {
+	return nil, nil
+}
+
+func (c *countingK8sClient) ListVolumeAttachments(context.Context) ([]storagev1.VolumeAttachment, error) {
+	return nil, nil
+}
+
+func (c *countingK8sClient) GetCSIDriverPods(context.Context, string) ([]corev1.Pod, error) {
+	return nil, nil
+}
+
+type countingTrueNASClient struct {
+	volumeCalls   int32
+	snapshotCalls int32
+}
+
+func (c *countingTrueNASClient) ListVolumes(context.Context) ([]truenas.Volume, error) {
+	atomic.AddInt32(&c.volumeCalls, 1)
+	return []truenas.Volume{{Name: "vol-1"}}, nil
+}
+
+func (c *countingTrueNASClient) ListSnapshots(context.Context) ([]truenas.Snapshot, error) {
+	atomic.AddInt32(&c.snapshotCalls, 1)
+	return []truenas.Snapshot{{Name: "snap-1"}}, nil
+}
+
+func (c *countingTrueNASClient) ListPools(context.Context) ([]truenas.Pool, error) {
+	return nil, nil
+}
+
+func (c *countingTrueNASClient) GetSystemInfo(context.Context) (*truenas.SystemInfo, error) {
+	return nil, nil
+}
+
+func (c *countingTrueNASClient) TestConnection(context.Context) error { return nil }
+
+func TestWrapK8sClient_CachesListCallsWithinTTL(t *testing.T) {
+	base := &countingK8sClient{}
+	cache := NewCache(Config{Enabled: true, TTL: time.Minute, MaxSize: 10})
+	wrapped := WrapK8sClient(base, cache)
+
+	ctx := context.Background()
+	_, err := wrapped.ListPersistentVolumeClaims(ctx, "apps")
+	require.NoError(t, err)
+	_, err = wrapped.ListPersistentVolumeClaims(ctx, "apps")
+	require.NoError(t, err)
+
+	require.Equal(t, int32(1), atomic.LoadInt32(&base.pvcCalls))
+}
+
+func TestWrapTrueNASClient_CachesListCallsWithinTTL(t *testing.T) {
+	base := &countingTrueNASClient{}
+	cache := NewCache(Config{Enabled: true, TTL: time.Minute, MaxSize: 10})
+	wrapped := WrapTrueNASClient(base, cache)
+
+	ctx := context.Background()
+	_, err := wrapped.ListVolumes(ctx)
+	require.NoError(t, err)
+	_, err = wrapped.ListVolumes(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, int32(1), atomic.LoadInt32(&base.volumeCalls))
+}
+
+func TestWrapK8sClient_DisabledReturnsBase(t *testing.T) {
+	base := &countingK8sClient{}
+	cache := NewCache(Config{Enabled: false})
+	wrapped := WrapK8sClient(base, cache)
+	require.Equal(t, base, wrapped)
+}

--- a/go/pkg/inventorycache/cached_k8s.go
+++ b/go/pkg/inventorycache/cached_k8s.go
@@ -30,29 +30,45 @@ func WrapK8sClient(base k8s.Client, cache *Cache) k8s.Client {
 }
 
 func (c *cachedK8sClient) ListPersistentVolumes(ctx context.Context) ([]corev1.PersistentVolume, error) {
-	return GetOrLoad(c.cache, opK8sAllPVs, opK8sAllPVs, func() ([]corev1.PersistentVolume, error) {
+	res, err := GetOrLoad(c.cache, opK8sAllPVs, opK8sAllPVs, func() ([]corev1.PersistentVolume, error) {
 		return c.base.ListPersistentVolumes(ctx)
 	})
+	if err != nil {
+		return nil, err
+	}
+	return cloneSlice(res), nil
 }
 
 func (c *cachedK8sClient) ListPersistentVolumeClaims(ctx context.Context, namespace string) ([]corev1.PersistentVolumeClaim, error) {
 	key := NamespaceKey(opK8sPVCs, namespace)
-	return GetOrLoad(c.cache, opK8sPVCs, key, func() ([]corev1.PersistentVolumeClaim, error) {
+	res, err := GetOrLoad(c.cache, opK8sPVCs, key, func() ([]corev1.PersistentVolumeClaim, error) {
 		return c.base.ListPersistentVolumeClaims(ctx, namespace)
 	})
+	if err != nil {
+		return nil, err
+	}
+	return cloneSlice(res), nil
 }
 
 func (c *cachedK8sClient) ListVolumeSnapshots(ctx context.Context, namespace string) ([]snapshotv1.VolumeSnapshot, error) {
 	key := NamespaceKey(opK8sSnaps, namespace)
-	return GetOrLoad(c.cache, opK8sSnaps, key, func() ([]snapshotv1.VolumeSnapshot, error) {
+	res, err := GetOrLoad(c.cache, opK8sSnaps, key, func() ([]snapshotv1.VolumeSnapshot, error) {
 		return c.base.ListVolumeSnapshots(ctx, namespace)
 	})
+	if err != nil {
+		return nil, err
+	}
+	return cloneSlice(res), nil
 }
 
 func (c *cachedK8sClient) ListDemocraticCSIPersistentVolumes(ctx context.Context) ([]corev1.PersistentVolume, error) {
-	return GetOrLoad(c.cache, opK8sPVs, opK8sPVs, func() ([]corev1.PersistentVolume, error) {
+	res, err := GetOrLoad(c.cache, opK8sPVs, opK8sPVs, func() ([]corev1.PersistentVolume, error) {
 		return c.base.ListDemocraticCSIPersistentVolumes(ctx)
 	})
+	if err != nil {
+		return nil, err
+	}
+	return cloneSlice(res), nil
 }
 
 func (c *cachedK8sClient) ListUnboundPersistentVolumeClaims(ctx context.Context, namespace string) ([]corev1.PersistentVolumeClaim, error) {

--- a/go/pkg/inventorycache/cached_k8s.go
+++ b/go/pkg/inventorycache/cached_k8s.go
@@ -36,7 +36,7 @@ func (c *cachedK8sClient) ListPersistentVolumes(ctx context.Context) ([]corev1.P
 	if err != nil {
 		return nil, err
 	}
-	return cloneSlice(res), nil
+	return clonePersistentVolumes(res), nil
 }
 
 func (c *cachedK8sClient) ListPersistentVolumeClaims(ctx context.Context, namespace string) ([]corev1.PersistentVolumeClaim, error) {
@@ -47,7 +47,7 @@ func (c *cachedK8sClient) ListPersistentVolumeClaims(ctx context.Context, namesp
 	if err != nil {
 		return nil, err
 	}
-	return cloneSlice(res), nil
+	return clonePersistentVolumeClaims(res), nil
 }
 
 func (c *cachedK8sClient) ListVolumeSnapshots(ctx context.Context, namespace string) ([]snapshotv1.VolumeSnapshot, error) {
@@ -58,7 +58,7 @@ func (c *cachedK8sClient) ListVolumeSnapshots(ctx context.Context, namespace str
 	if err != nil {
 		return nil, err
 	}
-	return cloneSlice(res), nil
+	return cloneVolumeSnapshots(res), nil
 }
 
 func (c *cachedK8sClient) ListDemocraticCSIPersistentVolumes(ctx context.Context) ([]corev1.PersistentVolume, error) {
@@ -68,7 +68,7 @@ func (c *cachedK8sClient) ListDemocraticCSIPersistentVolumes(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	return cloneSlice(res), nil
+	return clonePersistentVolumes(res), nil
 }
 
 func (c *cachedK8sClient) ListUnboundPersistentVolumeClaims(ctx context.Context, namespace string) ([]corev1.PersistentVolumeClaim, error) {

--- a/go/pkg/inventorycache/cached_k8s.go
+++ b/go/pkg/inventorycache/cached_k8s.go
@@ -1,0 +1,123 @@
+package inventorycache
+
+import (
+	"context"
+
+	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
+	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/k8s"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+)
+
+const (
+	opK8sAllPVs  = "k8s_all_pvs"
+	opK8sPVs     = "k8s_pvs"
+	opK8sPVCs    = "k8s_pvcs"
+	opK8sSnaps   = "k8s_snapshots"
+)
+
+type cachedK8sClient struct {
+	base  k8s.Client
+	cache *Cache
+}
+
+// WrapK8sClient returns a caching decorator when enabled, otherwise the base client.
+func WrapK8sClient(base k8s.Client, cache *Cache) k8s.Client {
+	if cache == nil || !cache.Enabled() {
+		return base
+	}
+	return &cachedK8sClient{base: base, cache: cache}
+}
+
+func (c *cachedK8sClient) ListPersistentVolumes(ctx context.Context) ([]corev1.PersistentVolume, error) {
+	return GetOrLoad(c.cache, opK8sAllPVs, opK8sAllPVs, func() ([]corev1.PersistentVolume, error) {
+		return c.base.ListPersistentVolumes(ctx)
+	})
+}
+
+func (c *cachedK8sClient) ListPersistentVolumeClaims(ctx context.Context, namespace string) ([]corev1.PersistentVolumeClaim, error) {
+	key := NamespaceKey(opK8sPVCs, namespace)
+	return GetOrLoad(c.cache, opK8sPVCs, key, func() ([]corev1.PersistentVolumeClaim, error) {
+		return c.base.ListPersistentVolumeClaims(ctx, namespace)
+	})
+}
+
+func (c *cachedK8sClient) ListVolumeSnapshots(ctx context.Context, namespace string) ([]snapshotv1.VolumeSnapshot, error) {
+	key := NamespaceKey(opK8sSnaps, namespace)
+	return GetOrLoad(c.cache, opK8sSnaps, key, func() ([]snapshotv1.VolumeSnapshot, error) {
+		return c.base.ListVolumeSnapshots(ctx, namespace)
+	})
+}
+
+func (c *cachedK8sClient) ListDemocraticCSIPersistentVolumes(ctx context.Context) ([]corev1.PersistentVolume, error) {
+	return GetOrLoad(c.cache, opK8sPVs, opK8sPVs, func() ([]corev1.PersistentVolume, error) {
+		return c.base.ListDemocraticCSIPersistentVolumes(ctx)
+	})
+}
+
+func (c *cachedK8sClient) ListUnboundPersistentVolumeClaims(ctx context.Context, namespace string) ([]corev1.PersistentVolumeClaim, error) {
+	pvcs, err := c.ListPersistentVolumeClaims(ctx, namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	var unbound []corev1.PersistentVolumeClaim
+	for _, pvc := range pvcs {
+		if pvc.Status.Phase == corev1.ClaimPending {
+			unbound = append(unbound, pvc)
+		}
+	}
+	return unbound, nil
+}
+
+func (c *cachedK8sClient) ListStorageClasses(ctx context.Context) ([]storagev1.StorageClass, error) {
+	return c.base.ListStorageClasses(ctx)
+}
+
+func (c *cachedK8sClient) ListPods(ctx context.Context, namespace string) ([]corev1.Pod, error) {
+	return c.base.ListPods(ctx, namespace)
+}
+
+func (c *cachedK8sClient) ListNamespaces(ctx context.Context) ([]corev1.Namespace, error) {
+	return c.base.ListNamespaces(ctx)
+}
+
+func (c *cachedK8sClient) GetNamespace(ctx context.Context, name string) (*corev1.Namespace, error) {
+	return c.base.GetNamespace(ctx, name)
+}
+
+func (c *cachedK8sClient) ListPersistentVolumesByStorageClass(ctx context.Context, storageClass string) ([]corev1.PersistentVolume, error) {
+	return c.base.ListPersistentVolumesByStorageClass(ctx, storageClass)
+}
+
+func (c *cachedK8sClient) ListPersistentVolumeClaimsByStorageClass(ctx context.Context, namespace, storageClass string) ([]corev1.PersistentVolumeClaim, error) {
+	return c.base.ListPersistentVolumeClaimsByStorageClass(ctx, namespace, storageClass)
+}
+
+func (c *cachedK8sClient) TestConnection(ctx context.Context) error {
+	return c.base.TestConnection(ctx)
+}
+
+func (c *cachedK8sClient) ValidateRBACPermissions(ctx context.Context) (*k8s.RBACValidationResult, error) {
+	return c.base.ValidateRBACPermissions(ctx)
+}
+
+func (c *cachedK8sClient) GetClusterInfo(ctx context.Context) (*k8s.ClusterInfo, error) {
+	return c.base.GetClusterInfo(ctx)
+}
+
+func (c *cachedK8sClient) ListCSINodes(ctx context.Context) ([]storagev1.CSINode, error) {
+	return c.base.ListCSINodes(ctx)
+}
+
+func (c *cachedK8sClient) ListCSIDrivers(ctx context.Context) ([]storagev1.CSIDriver, error) {
+	return c.base.ListCSIDrivers(ctx)
+}
+
+func (c *cachedK8sClient) ListVolumeAttachments(ctx context.Context) ([]storagev1.VolumeAttachment, error) {
+	return c.base.ListVolumeAttachments(ctx)
+}
+
+func (c *cachedK8sClient) GetCSIDriverPods(ctx context.Context, namespace string) ([]corev1.Pod, error) {
+	return c.base.GetCSIDriverPods(ctx, namespace)
+}

--- a/go/pkg/inventorycache/cached_truenas.go
+++ b/go/pkg/inventorycache/cached_truenas.go
@@ -1,0 +1,49 @@
+package inventorycache
+
+import (
+	"context"
+
+	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/truenas"
+)
+
+const (
+	opTrueNASDatasets  = "truenas_datasets"
+	opTrueNASSnapshots = "truenas_snapshots"
+)
+
+type cachedTrueNASClient struct {
+	base  truenas.Client
+	cache *Cache
+}
+
+// WrapTrueNASClient returns a caching decorator when enabled, otherwise the base client.
+func WrapTrueNASClient(base truenas.Client, cache *Cache) truenas.Client {
+	if cache == nil || !cache.Enabled() {
+		return base
+	}
+	return &cachedTrueNASClient{base: base, cache: cache}
+}
+
+func (c *cachedTrueNASClient) ListVolumes(ctx context.Context) ([]truenas.Volume, error) {
+	return GetOrLoad(c.cache, opTrueNASDatasets, opTrueNASDatasets, func() ([]truenas.Volume, error) {
+		return c.base.ListVolumes(ctx)
+	})
+}
+
+func (c *cachedTrueNASClient) ListSnapshots(ctx context.Context) ([]truenas.Snapshot, error) {
+	return GetOrLoad(c.cache, opTrueNASSnapshots, opTrueNASSnapshots, func() ([]truenas.Snapshot, error) {
+		return c.base.ListSnapshots(ctx)
+	})
+}
+
+func (c *cachedTrueNASClient) ListPools(ctx context.Context) ([]truenas.Pool, error) {
+	return c.base.ListPools(ctx)
+}
+
+func (c *cachedTrueNASClient) GetSystemInfo(ctx context.Context) (*truenas.SystemInfo, error) {
+	return c.base.GetSystemInfo(ctx)
+}
+
+func (c *cachedTrueNASClient) TestConnection(ctx context.Context) error {
+	return c.base.TestConnection(ctx)
+}

--- a/go/pkg/inventorycache/cached_truenas.go
+++ b/go/pkg/inventorycache/cached_truenas.go
@@ -25,15 +25,23 @@ func WrapTrueNASClient(base truenas.Client, cache *Cache) truenas.Client {
 }
 
 func (c *cachedTrueNASClient) ListVolumes(ctx context.Context) ([]truenas.Volume, error) {
-	return GetOrLoad(c.cache, opTrueNASDatasets, opTrueNASDatasets, func() ([]truenas.Volume, error) {
+	res, err := GetOrLoad(c.cache, opTrueNASDatasets, opTrueNASDatasets, func() ([]truenas.Volume, error) {
 		return c.base.ListVolumes(ctx)
 	})
+	if err != nil {
+		return nil, err
+	}
+	return cloneSlice(res), nil
 }
 
 func (c *cachedTrueNASClient) ListSnapshots(ctx context.Context) ([]truenas.Snapshot, error) {
-	return GetOrLoad(c.cache, opTrueNASSnapshots, opTrueNASSnapshots, func() ([]truenas.Snapshot, error) {
+	res, err := GetOrLoad(c.cache, opTrueNASSnapshots, opTrueNASSnapshots, func() ([]truenas.Snapshot, error) {
 		return c.base.ListSnapshots(ctx)
 	})
+	if err != nil {
+		return nil, err
+	}
+	return cloneSlice(res), nil
 }
 
 func (c *cachedTrueNASClient) ListPools(ctx context.Context) ([]truenas.Pool, error) {

--- a/go/pkg/inventorycache/cached_truenas.go
+++ b/go/pkg/inventorycache/cached_truenas.go
@@ -31,7 +31,7 @@ func (c *cachedTrueNASClient) ListVolumes(ctx context.Context) ([]truenas.Volume
 	if err != nil {
 		return nil, err
 	}
-	return cloneSlice(res), nil
+	return cloneTrueNASVolumes(res), nil
 }
 
 func (c *cachedTrueNASClient) ListSnapshots(ctx context.Context) ([]truenas.Snapshot, error) {
@@ -41,7 +41,7 @@ func (c *cachedTrueNASClient) ListSnapshots(ctx context.Context) ([]truenas.Snap
 	if err != nil {
 		return nil, err
 	}
-	return cloneSlice(res), nil
+	return cloneTrueNASSnapshots(res), nil
 }
 
 func (c *cachedTrueNASClient) ListPools(ctx context.Context) ([]truenas.Pool, error) {

--- a/go/pkg/inventorycache/copy.go
+++ b/go/pkg/inventorycache/copy.go
@@ -1,0 +1,9 @@
+package inventorycache
+
+// cloneSlice returns a shallow copy of a slice so callers cannot mutate cached data.
+func cloneSlice[T any](items []T) []T {
+	if len(items) == 0 {
+		return nil
+	}
+	return append([]T(nil), items...)
+}

--- a/go/pkg/inventorycache/copy.go
+++ b/go/pkg/inventorycache/copy.go
@@ -1,9 +1,73 @@
 package inventorycache
 
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
+	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/truenas"
+)
+
 // cloneSlice returns a shallow copy of a slice so callers cannot mutate cached data.
 func cloneSlice[T any](items []T) []T {
 	if len(items) == 0 {
 		return nil
 	}
 	return append([]T(nil), items...)
+}
+
+func cloneStringMap(m map[string]string) map[string]string {
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
+func cloneObjectMeta(meta metav1.ObjectMeta) metav1.ObjectMeta {
+	meta.Labels = cloneStringMap(meta.Labels)
+	meta.Annotations = cloneStringMap(meta.Annotations)
+	return meta
+}
+
+func clonePersistentVolumes(in []corev1.PersistentVolume) []corev1.PersistentVolume {
+	out := cloneSlice(in)
+	for i := range out {
+		out[i].ObjectMeta = cloneObjectMeta(out[i].ObjectMeta)
+	}
+	return out
+}
+
+func clonePersistentVolumeClaims(in []corev1.PersistentVolumeClaim) []corev1.PersistentVolumeClaim {
+	out := cloneSlice(in)
+	for i := range out {
+		out[i].ObjectMeta = cloneObjectMeta(out[i].ObjectMeta)
+	}
+	return out
+}
+
+func cloneVolumeSnapshots(in []snapshotv1.VolumeSnapshot) []snapshotv1.VolumeSnapshot {
+	out := cloneSlice(in)
+	for i := range out {
+		out[i].ObjectMeta = cloneObjectMeta(out[i].ObjectMeta)
+	}
+	return out
+}
+
+func cloneTrueNASVolumes(in []truenas.Volume) []truenas.Volume {
+	out := cloneSlice(in)
+	for i := range out {
+		out[i].Properties = cloneStringMap(out[i].Properties)
+	}
+	return out
+}
+
+func cloneTrueNASSnapshots(in []truenas.Snapshot) []truenas.Snapshot {
+	out := cloneSlice(in)
+	for i := range out {
+		out[i].Properties = cloneStringMap(out[i].Properties)
+	}
+	return out
 }

--- a/go/pkg/inventorycache/copy.go
+++ b/go/pkg/inventorycache/copy.go
@@ -1,18 +1,20 @@
 package inventorycache
 
 import (
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
 	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/truenas"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // cloneSlice returns a shallow copy of a slice so callers cannot mutate cached data.
 func cloneSlice[T any](items []T) []T {
-	if len(items) == 0 {
+	if items == nil {
 		return nil
 	}
-	return append([]T(nil), items...)
+	if len(items) == 0 {
+		return []T{}
+	}
+	return append([]T{}, items...)
 }
 
 func cloneStringMap(m map[string]string) map[string]string {
@@ -26,32 +28,35 @@ func cloneStringMap(m map[string]string) map[string]string {
 	return out
 }
 
-func cloneObjectMeta(meta metav1.ObjectMeta) metav1.ObjectMeta {
-	meta.Labels = cloneStringMap(meta.Labels)
-	meta.Annotations = cloneStringMap(meta.Annotations)
-	return meta
-}
-
 func clonePersistentVolumes(in []corev1.PersistentVolume) []corev1.PersistentVolume {
-	out := cloneSlice(in)
-	for i := range out {
-		out[i].ObjectMeta = cloneObjectMeta(out[i].ObjectMeta)
+	if in == nil {
+		return nil
+	}
+	out := make([]corev1.PersistentVolume, len(in))
+	for i := range in {
+		out[i] = *in[i].DeepCopy()
 	}
 	return out
 }
 
 func clonePersistentVolumeClaims(in []corev1.PersistentVolumeClaim) []corev1.PersistentVolumeClaim {
-	out := cloneSlice(in)
-	for i := range out {
-		out[i].ObjectMeta = cloneObjectMeta(out[i].ObjectMeta)
+	if in == nil {
+		return nil
+	}
+	out := make([]corev1.PersistentVolumeClaim, len(in))
+	for i := range in {
+		out[i] = *in[i].DeepCopy()
 	}
 	return out
 }
 
 func cloneVolumeSnapshots(in []snapshotv1.VolumeSnapshot) []snapshotv1.VolumeSnapshot {
-	out := cloneSlice(in)
-	for i := range out {
-		out[i].ObjectMeta = cloneObjectMeta(out[i].ObjectMeta)
+	if in == nil {
+		return nil
+	}
+	out := make([]snapshotv1.VolumeSnapshot, len(in))
+	for i := range in {
+		out[i] = *in[i].DeepCopy()
 	}
 	return out
 }

--- a/go/pkg/inventorycache/copy_test.go
+++ b/go/pkg/inventorycache/copy_test.go
@@ -9,12 +9,19 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestCloneSlice_ReturnsIndependentCopy(t *testing.T) {
-	original := []corev1.PersistentVolume{{ObjectMeta: metav1.ObjectMeta{Name: "pv-1"}}}
-	copied := cloneSlice(original)
+func TestClonePersistentVolumes_ReturnsIndependentCopy(t *testing.T) {
+	original := []corev1.PersistentVolume{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "pv-1",
+			Labels: map[string]string{"app": "demo"},
+		},
+	}}
+	copied := clonePersistentVolumes(original)
 	require.Len(t, copied, 1)
 	copied[0].Name = "mutated"
+	copied[0].Labels["app"] = "changed"
 	require.Equal(t, "pv-1", original[0].Name)
+	require.Equal(t, "demo", original[0].Labels["app"])
 }
 
 func TestCache_GetOrLoad_ExpiresAtBoundary(t *testing.T) {

--- a/go/pkg/inventorycache/copy_test.go
+++ b/go/pkg/inventorycache/copy_test.go
@@ -1,0 +1,43 @@
+package inventorycache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestCloneSlice_ReturnsIndependentCopy(t *testing.T) {
+	original := []corev1.PersistentVolume{{ObjectMeta: metav1.ObjectMeta{Name: "pv-1"}}}
+	copied := cloneSlice(original)
+	require.Len(t, copied, 1)
+	copied[0].Name = "mutated"
+	require.Equal(t, "pv-1", original[0].Name)
+}
+
+func TestCache_GetOrLoad_ExpiresAtBoundary(t *testing.T) {
+	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
+	cache := NewCache(Config{
+		Enabled: true,
+		TTL:     time.Minute,
+		MaxSize: 10,
+		Now:     func() time.Time { return now },
+	})
+
+	var loads int
+	loader := func() (int, error) {
+		loads++
+		return loads, nil
+	}
+
+	_, err := GetOrLoad(cache, "op", "key", loader)
+	require.NoError(t, err)
+	require.Equal(t, 1, loads)
+
+	now = now.Add(time.Minute)
+	_, err = GetOrLoad(cache, "op", "key", loader)
+	require.NoError(t, err)
+	require.Equal(t, 2, loads)
+}

--- a/go/pkg/inventorycache/copy_test.go
+++ b/go/pkg/inventorycache/copy_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/truenas"
 )
 
 func TestClonePersistentVolumes_ReturnsIndependentCopy(t *testing.T) {
@@ -15,13 +17,30 @@ func TestClonePersistentVolumes_ReturnsIndependentCopy(t *testing.T) {
 			Name:   "pv-1",
 			Labels: map[string]string{"app": "demo"},
 		},
+		Spec: corev1.PersistentVolumeSpec{
+			PersistentVolumeSource: corev1.PersistentVolumeSource{
+				CSI: &corev1.CSIPersistentVolumeSource{
+					Driver:       "org.democratic-csi.nfs",
+					VolumeHandle: "vol-1",
+				},
+			},
+		},
 	}}
 	copied := clonePersistentVolumes(original)
 	require.Len(t, copied, 1)
 	copied[0].Name = "mutated"
 	copied[0].Labels["app"] = "changed"
+	copied[0].Spec.CSI.VolumeHandle = "mutated-handle"
 	require.Equal(t, "pv-1", original[0].Name)
 	require.Equal(t, "demo", original[0].Labels["app"])
+	require.Equal(t, "vol-1", original[0].Spec.CSI.VolumeHandle)
+}
+
+func TestCloneSlice_PreservesEmptyNonNilSlice(t *testing.T) {
+	empty := []truenas.Volume{}
+	copied := cloneSlice(empty)
+	require.NotNil(t, copied)
+	require.Len(t, copied, 0)
 }
 
 func TestCache_GetOrLoad_ExpiresAtBoundary(t *testing.T) {

--- a/go/pkg/inventorycache/wire.go
+++ b/go/pkg/inventorycache/wire.go
@@ -1,0 +1,21 @@
+package inventorycache
+
+import (
+	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/config"
+	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/metrics"
+)
+
+// NewFromConfig builds an inventory cache from application config and optional metrics.
+func NewFromConfig(cfg config.PerformanceConfig, exporter *metrics.Exporter) *Cache {
+	var stats StatsRecorder
+	if exporter != nil {
+		stats = exporter.RecordInventoryCacheAccess
+	}
+
+	return NewCache(Config{
+		Enabled: cfg.Cache.Enabled,
+		TTL:     cfg.Cache.TTL,
+		MaxSize: cfg.Cache.MaxSize,
+		Stats:   stats,
+	})
+}

--- a/go/pkg/metrics/exporter.go
+++ b/go/pkg/metrics/exporter.go
@@ -25,6 +25,8 @@ type Exporter struct {
 	scanDuration           prometheus.Gauge
 	scanDurationHist       prometheus.Histogram
 	listDurationHist       *prometheus.HistogramVec
+	cacheHits              *prometheus.CounterVec
+	cacheMisses            *prometheus.CounterVec
 	totalPVs               prometheus.Gauge
 	totalPVCs              prometheus.Gauge
 	totalSnapshots         prometheus.Gauge
@@ -80,6 +82,16 @@ func NewExporter(config Config) *Exporter {
 		Buckets: listDurationBuckets,
 	}, []string{"phase"})
 
+	cacheHits := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "truenas_monitor_inventory_cache_hits_total",
+		Help: "Inventory cache hits by operation",
+	}, []string{"operation"})
+
+	cacheMisses := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "truenas_monitor_inventory_cache_misses_total",
+		Help: "Inventory cache misses by operation",
+	}, []string{"operation"})
+
 	totalPVs := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "truenas_monitor_pvs_total",
 		Help: "Total number of persistent volumes",
@@ -113,6 +125,8 @@ func NewExporter(config Config) *Exporter {
 		scanDuration,
 		scanDurationHist,
 		listDurationHist,
+		cacheHits,
+		cacheMisses,
 		totalPVs,
 		totalPVCs,
 		totalSnapshots,
@@ -147,6 +161,8 @@ func NewExporter(config Config) *Exporter {
 		scanDuration:           scanDuration,
 		scanDurationHist:       scanDurationHist,
 		listDurationHist:       listDurationHist,
+		cacheHits:              cacheHits,
+		cacheMisses:            cacheMisses,
 		totalPVs:               totalPVs,
 		totalPVCs:              totalPVCs,
 		totalSnapshots:         totalSnapshots,
@@ -206,6 +222,15 @@ func (e *Exporter) ObserveScanDuration(duration float64) {
 // ObserveListPhaseDuration records a list operation duration for a detection phase
 func (e *Exporter) ObserveListPhaseDuration(phase string, duration float64) {
 	e.listDurationHist.WithLabelValues(phase).Observe(duration)
+}
+
+// RecordInventoryCacheAccess increments cache hit or miss counters.
+func (e *Exporter) RecordInventoryCacheAccess(operation string, hit bool) {
+	if hit {
+		e.cacheHits.WithLabelValues(operation).Inc()
+		return
+	}
+	e.cacheMisses.WithLabelValues(operation).Inc()
 }
 
 // SetTotalPVs sets the total PVs metric

--- a/go/pkg/metrics/exporter_test.go
+++ b/go/pkg/metrics/exporter_test.go
@@ -51,3 +51,25 @@ func TestExporter_ObserveListPhaseDuration(t *testing.T) {
 	}
 	require.True(t, found, "list phase histogram sample not found")
 }
+
+func TestExporter_RecordInventoryCacheAccess(t *testing.T) {
+	exporter := NewExporter(Config{Enabled: true, Port: 0, Path: "/metrics"})
+
+	exporter.RecordInventoryCacheAccess("k8s_pvcs", false)
+	exporter.RecordInventoryCacheAccess("k8s_pvcs", true)
+
+	families, err := exporter.registry.Gather()
+	require.NoError(t, err)
+
+	var hits, misses float64
+	for _, family := range families {
+		switch family.GetName() {
+		case "truenas_monitor_inventory_cache_hits_total":
+			hits = family.GetMetric()[0].GetCounter().GetValue()
+		case "truenas_monitor_inventory_cache_misses_total":
+			misses = family.GetMetric()[0].GetCounter().GetValue()
+		}
+	}
+	require.Equal(t, float64(1), hits)
+	require.Equal(t, float64(1), misses)
+}

--- a/go/pkg/orphan/detector.go
+++ b/go/pkg/orphan/detector.go
@@ -257,23 +257,20 @@ func (d *Detector) detectOrphanedPVs(ctx context.Context, timings map[string]tim
 
 // detectOrphanedPVCs identifies unbound PVCs older than threshold
 func (d *Detector) detectOrphanedPVCs(ctx context.Context, namespace string, timings map[string]time.Duration) ([]OrphanedResource, int, error) {
-	var listDuration time.Duration
-
-	unboundStart := time.Now()
-	unboundPVCs, err := d.k8sClient.ListUnboundPersistentVolumeClaims(ctx, namespace)
-	listDuration += time.Since(unboundStart)
-	if err != nil {
-		return nil, 0, fmt.Errorf("failed to list unbound PVCs: %w", err)
-	}
-
-	allStart := time.Now()
+	listStart := time.Now()
 	allPVCs, err := d.k8sClient.ListPersistentVolumeClaims(ctx, namespace)
-	listDuration += time.Since(allStart)
-	if err != nil {
-		return nil, 0, fmt.Errorf("failed to list all PVCs: %w", err)
-	}
 	if timings != nil {
-		timings["k8s_pvcs"] = listDuration
+		timings["k8s_pvcs"] = time.Since(listStart)
+	}
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to list PVCs: %w", err)
+	}
+
+	var unboundPVCs []corev1.PersistentVolumeClaim
+	for _, pvc := range allPVCs {
+		if pvc.Status.Phase == corev1.ClaimPending {
+			unboundPVCs = append(unboundPVCs, pvc)
+		}
 	}
 
 	var orphaned []OrphanedResource

--- a/go/pkg/orphan/detector_test.go
+++ b/go/pkg/orphan/detector_test.go
@@ -1,12 +1,17 @@
 package orphan
 
 import (
+	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
+	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/k8s"
+	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/logging"
 	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/truenas"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -265,5 +270,132 @@ func TestHasCorrespondingTrueNASVolume_EmptyCSI(t *testing.T) {
 	}
 	if d.hasCorrespondingTrueNASVolume(pv, nil) {
 		t.Fatal("expected false when PV has no CSI source")
+	}
+}
+
+type pvcListSpyK8sClient struct {
+	pvcListCalls     int32
+	unboundListCalls int32
+}
+
+func (s *pvcListSpyK8sClient) ListPersistentVolumeClaims(context.Context, string) ([]corev1.PersistentVolumeClaim, error) {
+	atomic.AddInt32(&s.pvcListCalls, 1)
+	old := time.Now().Add(-48 * time.Hour)
+	return []corev1.PersistentVolumeClaim{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "pending-old",
+				Namespace:         "apps",
+				CreationTimestamp: metav1.NewTime(old),
+			},
+			Status: corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimPending},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "bound-old",
+				Namespace:         "apps",
+				CreationTimestamp: metav1.NewTime(old),
+			},
+			Status: corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimBound},
+		},
+	}, nil
+}
+
+func (s *pvcListSpyK8sClient) ListPersistentVolumes(context.Context) ([]corev1.PersistentVolume, error) {
+	return nil, nil
+}
+
+func (s *pvcListSpyK8sClient) ListVolumeSnapshots(context.Context, string) ([]snapshotv1.VolumeSnapshot, error) {
+	return nil, nil
+}
+
+func (s *pvcListSpyK8sClient) ListStorageClasses(context.Context) ([]storagev1.StorageClass, error) {
+	return nil, nil
+}
+
+func (s *pvcListSpyK8sClient) ListPods(context.Context, string) ([]corev1.Pod, error) {
+	return nil, nil
+}
+
+func (s *pvcListSpyK8sClient) ListNamespaces(context.Context) ([]corev1.Namespace, error) {
+	return nil, nil
+}
+
+func (s *pvcListSpyK8sClient) GetNamespace(context.Context, string) (*corev1.Namespace, error) {
+	return nil, nil
+}
+
+func (s *pvcListSpyK8sClient) ListPersistentVolumesByStorageClass(context.Context, string) ([]corev1.PersistentVolume, error) {
+	return nil, nil
+}
+
+func (s *pvcListSpyK8sClient) ListPersistentVolumeClaimsByStorageClass(context.Context, string, string) ([]corev1.PersistentVolumeClaim, error) {
+	return nil, nil
+}
+
+func (s *pvcListSpyK8sClient) ListDemocraticCSIPersistentVolumes(context.Context) ([]corev1.PersistentVolume, error) {
+	return nil, nil
+}
+
+func (s *pvcListSpyK8sClient) ListUnboundPersistentVolumeClaims(context.Context, string) ([]corev1.PersistentVolumeClaim, error) {
+	atomic.AddInt32(&s.unboundListCalls, 1)
+	return nil, nil
+}
+
+func (s *pvcListSpyK8sClient) TestConnection(context.Context) error { return nil }
+
+func (s *pvcListSpyK8sClient) ValidateRBACPermissions(context.Context) (*k8s.RBACValidationResult, error) {
+	return nil, nil
+}
+
+func (s *pvcListSpyK8sClient) GetClusterInfo(context.Context) (*k8s.ClusterInfo, error) {
+	return nil, nil
+}
+
+func (s *pvcListSpyK8sClient) ListCSINodes(context.Context) ([]storagev1.CSINode, error) {
+	return nil, nil
+}
+
+func (s *pvcListSpyK8sClient) ListCSIDrivers(context.Context) ([]storagev1.CSIDriver, error) {
+	return nil, nil
+}
+
+func (s *pvcListSpyK8sClient) ListVolumeAttachments(context.Context) ([]storagev1.VolumeAttachment, error) {
+	return nil, nil
+}
+
+func (s *pvcListSpyK8sClient) GetCSIDriverPods(context.Context, string) ([]corev1.Pod, error) {
+	return nil, nil
+}
+
+func TestDetectOrphanedPVCs_SingleListCall(t *testing.T) {
+	spy := &pvcListSpyK8sClient{}
+	logger, err := logging.NewLogger(logging.Config{Level: "error", Encoding: "json"})
+	if err != nil {
+		t.Fatalf("failed to create logger: %v", err)
+	}
+	d := &Detector{
+		k8sClient: spy,
+		logger:    logger,
+		config: Config{
+			AgeThreshold: 24 * time.Hour,
+		},
+	}
+
+	orphaned, total, err := d.detectOrphanedPVCs(context.Background(), "apps", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spy.pvcListCalls != 1 {
+		t.Fatalf("ListPersistentVolumeClaims calls = %d, want 1", spy.pvcListCalls)
+	}
+	if spy.unboundListCalls != 0 {
+		t.Fatalf("ListUnboundPersistentVolumeClaims calls = %d, want 0", spy.unboundListCalls)
+	}
+	if total != 2 {
+		t.Fatalf("total PVCs = %d, want 2", total)
+	}
+	if len(orphaned) != 1 {
+		t.Fatalf("orphaned PVCs = %d, want 1", len(orphaned))
 	}
 }

--- a/python/tests/unit/test_config.py
+++ b/python/tests/unit/test_config.py
@@ -294,3 +294,28 @@ class TestConfigClass:
         }
         assert config.orphan_threshold == timedelta(hours=48)
         assert config.snapshot_retention == timedelta(days=7)
+
+    def test_cache_config_properties(self):
+        """Cache config properties coerce and validate values."""
+        from datetime import timedelta
+
+        config = Config.__new__(Config)
+        config.data = {
+            "performance": {
+                "cache": {
+                    "enabled": "false",
+                    "ttl": "10m",
+                    "max_size": 500,
+                }
+            }
+        }
+        assert config.cache_enabled is False
+        assert config.cache_ttl == timedelta(minutes=10)
+        assert config.cache_max_size == 500
+
+        config.data["performance"]["cache"]["enabled"] = "true"
+        assert config.cache_enabled is True
+
+        with pytest.raises(ConfigurationError, match="max_size must be > 0"):
+            config.data["performance"]["cache"]["max_size"] = 0
+            _ = config.cache_max_size

--- a/python/tests/unit/test_inventory_cache.py
+++ b/python/tests/unit/test_inventory_cache.py
@@ -1,0 +1,64 @@
+"""Unit tests for inventory TTL cache."""
+
+from datetime import timedelta
+
+from truenas_storage_monitor.inventory_cache import InventoryCache, namespace_key
+
+
+def test_cache_hit_and_miss():
+    now = [1000.0]
+
+    cache = InventoryCache(
+        ttl=timedelta(minutes=1),
+        max_size=10,
+        now=lambda: now[0],
+    )
+
+    loads = {"count": 0}
+
+    def loader():
+        loads["count"] += 1
+        return "value"
+
+    assert cache.get_or_load("k8s_pvs", "k8s_pvs", loader) == "value"
+    assert cache.get_or_load("k8s_pvs", "k8s_pvs", loader) == "value"
+    assert loads["count"] == 1
+    assert cache.hits == 1
+    assert cache.misses == 1
+
+
+def test_cache_expiry():
+    now = [1000.0]
+    cache = InventoryCache(
+        ttl=timedelta(minutes=1),
+        now=lambda: now[0],
+    )
+
+    loads = {"count": 0}
+
+    def loader():
+        loads["count"] += 1
+        return loads["count"]
+
+    assert cache.get_or_load("k8s_pvs", "k8s_pvs", loader) == 1
+    now[0] += 120
+    assert cache.get_or_load("k8s_pvs", "k8s_pvs", loader) == 2
+    assert loads["count"] == 2
+
+
+def test_cache_disabled_passthrough():
+    cache = InventoryCache(ttl=timedelta(minutes=1), enabled=False)
+    loads = {"count": 0}
+
+    def loader():
+        loads["count"] += 1
+        return "direct"
+
+    cache.get_or_load("k8s_pvs", "k8s_pvs", loader)
+    cache.get_or_load("k8s_pvs", "k8s_pvs", loader)
+    assert loads["count"] == 2
+
+
+def test_namespace_key():
+    assert namespace_key("k8s_pvcs", None) == "k8s_pvcs:*"
+    assert namespace_key("k8s_pvcs", "apps") == "k8s_pvcs:apps"

--- a/python/tests/unit/test_monitor.py
+++ b/python/tests/unit/test_monitor.py
@@ -31,6 +31,7 @@ class TestMonitor:
         config.orphan_threshold = timedelta(hours=24)
         config.snapshot_retention = timedelta(days=30)
         config.metrics_enabled = False
+        config.cache_enabled = False
         return config
 
     @pytest.fixture
@@ -56,8 +57,12 @@ class TestMonitor:
             assert monitor.config == mock_config
             mock_config.k8s_config.assert_called_once()
             mock_config.truenas_config.assert_called_once()
-            mock_k8s.assert_called_once_with(mock_config.k8s_config.return_value)
-            mock_truenas.assert_called_once_with(mock_config.truenas_config.return_value)
+            mock_k8s.assert_called_once_with(
+                mock_config.k8s_config.return_value, inventory_cache=None
+            )
+            mock_truenas.assert_called_once_with(
+                mock_config.truenas_config.return_value, inventory_cache=None
+            )
 
     def test_find_orphaned_resources_success(self, monitor):
         """Test successful orphaned resource detection."""

--- a/python/tests/unit/test_monitor.py
+++ b/python/tests/unit/test_monitor.py
@@ -64,6 +64,34 @@ class TestMonitor:
                 mock_config.truenas_config.return_value, inventory_cache=None
             )
 
+    def test_monitor_initialization_with_cache_enabled(self, mock_config):
+        """Monitor shares one InventoryCache between clients when enabled."""
+        mock_config.cache_enabled = True
+        mock_config.cache_ttl = timedelta(minutes=5)
+        mock_config.cache_max_size = 1000
+
+        with (
+            patch("truenas_storage_monitor.monitor.K8sClient") as mock_k8s_cls,
+            patch("truenas_storage_monitor.monitor.TrueNASClient") as mock_truenas_cls,
+            patch("truenas_storage_monitor.monitor.InventoryCache") as mock_cache_cls,
+        ):
+            cache_instance = Mock()
+            mock_cache_cls.return_value = cache_instance
+            monitor = Monitor(mock_config)
+
+            mock_cache_cls.assert_called_once_with(
+                ttl=timedelta(minutes=5),
+                max_size=1000,
+                enabled=True,
+            )
+            mock_k8s_cls.assert_called_once_with(
+                mock_config.k8s_config.return_value, inventory_cache=cache_instance
+            )
+            mock_truenas_cls.assert_called_once_with(
+                mock_config.truenas_config.return_value, inventory_cache=cache_instance
+            )
+            assert monitor.config == mock_config
+
     def test_find_orphaned_resources_success(self, monitor):
         """Test successful orphaned resource detection."""
         old_created = utc_now() - timedelta(hours=25)

--- a/python/truenas_storage_monitor/config.py
+++ b/python/truenas_storage_monitor/config.py
@@ -144,7 +144,16 @@ class Config:
     @property
     def cache_enabled(self) -> bool:
         """Whether in-process inventory cache is enabled."""
-        return bool(self.performance.get("cache", {}).get("enabled", True))
+        raw = self.performance.get("cache", {}).get("enabled", True)
+        if isinstance(raw, bool):
+            return raw
+        if isinstance(raw, str):
+            normalized = raw.strip().lower()
+            if normalized in {"true", "1", "yes", "on"}:
+                return True
+            if normalized in {"false", "0", "no", "off"}:
+                return False
+        raise ConfigurationError(f"Invalid cache enabled flag: {raw!r}")
 
     @property
     def cache_ttl(self) -> timedelta:
@@ -155,7 +164,16 @@ class Config:
     @property
     def cache_max_size(self) -> int:
         """Inventory cache max entries from performance.cache.max_size."""
-        return int(self.performance.get("cache", {}).get("max_size", 1000))
+        raw = self.performance.get("cache", {}).get("max_size", 1000)
+        if isinstance(raw, bool):
+            raise ConfigurationError(f"Invalid cache max_size value: {raw!r}")
+        try:
+            size = int(raw)
+        except (TypeError, ValueError) as exc:
+            raise ConfigurationError(f"Invalid cache max_size value: {raw!r}") from exc
+        if size <= 0:
+            raise ConfigurationError(f"cache max_size must be > 0: {raw!r}")
+        return size
 
 
 def parse_truenas_url(url: str) -> Tuple[str, int, bool]:

--- a/python/truenas_storage_monitor/config.py
+++ b/python/truenas_storage_monitor/config.py
@@ -136,6 +136,27 @@ class Config:
         """Whether Prometheus metrics export is enabled."""
         return bool(self.get("metrics.enabled", False))
 
+    @property
+    def performance(self) -> Dict[str, Any]:
+        """Performance tuning configuration."""
+        return self.get("performance", {})
+
+    @property
+    def cache_enabled(self) -> bool:
+        """Whether in-process inventory cache is enabled."""
+        return bool(self.performance.get("cache", {}).get("enabled", True))
+
+    @property
+    def cache_ttl(self) -> timedelta:
+        """Inventory cache TTL from performance.cache.ttl."""
+        raw = self.performance.get("cache", {}).get("ttl", "5m")
+        return parse_duration(raw)
+
+    @property
+    def cache_max_size(self) -> int:
+        """Inventory cache max entries from performance.cache.max_size."""
+        return int(self.performance.get("cache", {}).get("max_size", 1000))
+
 
 def parse_truenas_url(url: str) -> Tuple[str, int, bool]:
     """Parse a TrueNAS URL into host, port, and TLS scheme flag."""

--- a/python/truenas_storage_monitor/inventory_cache.py
+++ b/python/truenas_storage_monitor/inventory_cache.py
@@ -1,0 +1,76 @@
+"""In-process TTL cache for expensive inventory list operations."""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Any, Callable, Dict, Optional, TypeVar
+
+T = TypeVar("T")
+
+
+@dataclass
+class _CacheEntry:
+    value: Any
+    expires_at: float
+    inserted_at: float
+
+
+class InventoryCache:
+    """Thread-safe TTL cache with optional max size."""
+
+    def __init__(
+        self,
+        ttl: timedelta,
+        max_size: int = 1000,
+        enabled: bool = True,
+        now: Optional[Callable[[], float]] = None,
+    ) -> None:
+        self._ttl = ttl.total_seconds()
+        self._max_size = max(1, max_size)
+        self._enabled = enabled
+        self._now = now or time.time
+        self._lock = threading.Lock()
+        self._entries: Dict[str, _CacheEntry] = {}
+        self.hits = 0
+        self.misses = 0
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    def get_or_load(self, operation: str, key: str, loader: Callable[[], T]) -> T:
+        """Return cached value or load via loader when missing or expired."""
+        if not self._enabled:
+            return loader()
+
+        now = self._now()
+        with self._lock:
+            entry = self._entries.get(key)
+            if entry is not None and now <= entry.expires_at:
+                self.hits += 1
+                return entry.value  # type: ignore[return-value]
+
+        loaded = loader()
+
+        with self._lock:
+            self.misses += 1
+            self._entries[key] = _CacheEntry(
+                value=loaded,
+                expires_at=now + self._ttl,
+                inserted_at=now,
+            )
+            if len(self._entries) > self._max_size:
+                oldest_key = min(self._entries, key=lambda k: self._entries[k].inserted_at)
+                del self._entries[oldest_key]
+
+        return loaded
+
+
+def namespace_key(prefix: str, namespace: Optional[str]) -> str:
+    """Build a cache key with optional namespace scope."""
+    if not namespace:
+        return f"{prefix}:*"
+    return f"{prefix}:{namespace}"

--- a/python/truenas_storage_monitor/k8s_client.py
+++ b/python/truenas_storage_monitor/k8s_client.py
@@ -4,12 +4,15 @@ import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from enum import Enum
-from typing import List, Dict, Optional, Any, Generator
+from typing import List, Dict, Optional, Any, Generator, TYPE_CHECKING
 
 from kubernetes import client as k8s_client, config, watch
 from kubernetes.client.rest import ApiException
 
 from .time_utils import ensure_utc, utc_now
+
+if TYPE_CHECKING:
+    from .inventory_cache import InventoryCache
 
 logger = logging.getLogger(__name__)
 
@@ -101,13 +104,15 @@ class OrphanedResource:
 class K8sClient:
     """Kubernetes client wrapper for storage operations."""
 
-    def __init__(self, config_obj: K8sConfig):
+    def __init__(self, config_obj: K8sConfig, inventory_cache: Optional["InventoryCache"] = None):
         """Initialize Kubernetes client.
 
         Args:
             config_obj: Kubernetes client configuration
+            inventory_cache: Optional TTL cache for list operations
         """
         self.config = config_obj
+        self._cache = inventory_cache
 
         # Load Kubernetes configuration
         if config_obj.in_cluster:
@@ -142,11 +147,13 @@ class K8sClient:
             raise
 
     def get_persistent_volumes(self) -> List[PersistentVolumeInfo]:
-        """Get all PersistentVolumes managed by the CSI driver.
+        """Get all PersistentVolumes managed by the CSI driver."""
+        if self._cache is not None:
+            return self._cache.get_or_load("k8s_pvs", "k8s_pvs", self._load_persistent_volumes)
+        return self._load_persistent_volumes()
 
-        Returns:
-            List of PersistentVolumeInfo objects
-        """
+    def _load_persistent_volumes(self) -> List[PersistentVolumeInfo]:
+        """Fetch PersistentVolumes from the Kubernetes API."""
         try:
             pvs = self.core_v1.list_persistent_volume()
             result = []
@@ -188,7 +195,22 @@ class K8sClient:
     def get_persistent_volume_claims(
         self, namespace: Optional[str] = None
     ) -> List[PersistentVolumeClaimInfo]:
-        """Get all PersistentVolumeClaims.
+        """Get all PersistentVolumeClaims."""
+        if self._cache is not None:
+            from .inventory_cache import namespace_key
+
+            key = namespace_key("k8s_pvcs", namespace or self.config.namespace)
+            return self._cache.get_or_load(
+                "k8s_pvcs",
+                key,
+                lambda: self._load_persistent_volume_claims(namespace),
+            )
+        return self._load_persistent_volume_claims(namespace)
+
+    def _load_persistent_volume_claims(
+        self, namespace: Optional[str] = None
+    ) -> List[PersistentVolumeClaimInfo]:
+        """Fetch PersistentVolumeClaims from the Kubernetes API.
 
         Args:
             namespace: Namespace to filter by (None for all namespaces)
@@ -234,7 +256,20 @@ class K8sClient:
             raise
 
     def get_volume_snapshots(self, namespace: Optional[str] = None) -> List[VolumeSnapshotInfo]:
-        """Get all VolumeSnapshots.
+        """Get all VolumeSnapshots."""
+        if self._cache is not None:
+            from .inventory_cache import namespace_key
+
+            key = namespace_key("k8s_snapshots", namespace or self.config.namespace)
+            return self._cache.get_or_load(
+                "k8s_snapshots",
+                key,
+                lambda: self._load_volume_snapshots(namespace),
+            )
+        return self._load_volume_snapshots(namespace)
+
+    def _load_volume_snapshots(self, namespace: Optional[str] = None) -> List[VolumeSnapshotInfo]:
+        """Fetch VolumeSnapshots from the Kubernetes API.
 
         Args:
             namespace: Namespace to filter by (None for all namespaces)

--- a/python/truenas_storage_monitor/monitor.py
+++ b/python/truenas_storage_monitor/monitor.py
@@ -13,6 +13,7 @@ from .k8s_client import (
 from .truenas_client import TrueNASClient, VolumeInfo, SnapshotInfo
 from .config import Config
 from .exceptions import TrueNASMonitorError
+from .inventory_cache import InventoryCache
 from .observability import ScanObservability
 from .time_utils import ensure_utc, resource_age, utc_now
 
@@ -25,8 +26,17 @@ class Monitor:
     def __init__(self, config: Config):
         """Initialize the monitor with configuration."""
         self.config = config
-        self.k8s_client = K8sClient(config.k8s_config())
-        self.truenas_client = TrueNASClient(config.truenas_config())
+        inventory_cache = None
+        if config.cache_enabled:
+            inventory_cache = InventoryCache(
+                ttl=config.cache_ttl,
+                max_size=config.cache_max_size,
+                enabled=True,
+            )
+        self.k8s_client = K8sClient(config.k8s_config(), inventory_cache=inventory_cache)
+        self.truenas_client = TrueNASClient(
+            config.truenas_config(), inventory_cache=inventory_cache
+        )
 
     def find_orphaned_resources(
         self,

--- a/python/truenas_storage_monitor/truenas_client.py
+++ b/python/truenas_storage_monitor/truenas_client.py
@@ -3,7 +3,7 @@
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import List, Dict, Optional, Any
+from typing import List, Dict, Optional, Any, TYPE_CHECKING
 from urllib.parse import quote
 
 import requests
@@ -11,6 +11,9 @@ from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 
 from .exceptions import TrueNASMonitorError
+
+if TYPE_CHECKING:
+    from .inventory_cache import InventoryCache
 
 logger = logging.getLogger(__name__)
 
@@ -121,14 +124,16 @@ class OrphanedVolume:
 class TrueNASClient:
     """Client for TrueNAS REST API."""
 
-    def __init__(self, config: TrueNASConfig):
+    def __init__(self, config: TrueNASConfig, inventory_cache: Optional["InventoryCache"] = None):
         """Initialize TrueNAS client.
 
         Args:
             config: TrueNAS client configuration
+            inventory_cache: Optional TTL cache for list operations
         """
         self.config = config
         self.base_url = config.base_url
+        self._cache = inventory_cache
 
         # Setup session with retry logic
         self.session = requests.Session()
@@ -254,11 +259,15 @@ class TrueNASClient:
             raise TrueNASError(f"Failed to get datasets: {str(e)}")
 
     def get_volumes(self) -> List[VolumeInfo]:
-        """Get all iSCSI volumes (extents).
+        """Get all iSCSI volumes (extents)."""
+        if self._cache is not None:
+            return self._cache.get_or_load(
+                "truenas_datasets", "truenas_datasets", self._load_volumes
+            )
+        return self._load_volumes()
 
-        Returns:
-            List of VolumeInfo objects
-        """
+    def _load_volumes(self) -> List[VolumeInfo]:
+        """Fetch iSCSI volumes from TrueNAS."""
         try:
             response = self.session.get(
                 f"{self.base_url}/iscsi/extent", timeout=self.config.timeout
@@ -302,7 +311,17 @@ class TrueNASClient:
             raise TrueNASError(f"Failed to get NFS shares: {str(e)}")
 
     def get_snapshots(self, dataset: Optional[str] = None) -> List[SnapshotInfo]:
-        """Get all snapshots, optionally filtered by dataset.
+        """Get all snapshots, optionally filtered by dataset."""
+        if self._cache is not None and dataset is None:
+            return self._cache.get_or_load(
+                "truenas_snapshots",
+                "truenas_snapshots",
+                lambda: self._load_snapshots(None),
+            )
+        return self._load_snapshots(dataset)
+
+    def _load_snapshots(self, dataset: Optional[str] = None) -> List[SnapshotInfo]:
+        """Fetch snapshots from TrueNAS.
 
         Args:
             dataset: Dataset name to filter snapshots


### PR DESCRIPTION
## Summary

- Mark PR 9 **Done** in remediation plan (merge `5829adf`, [#59](https://github.com/tomazb/kubernetes-truenas-democratic-tool/pull/59)); set **Next up: PR 10**.
- Add in-process TTL inventory cache for Go monitor/API and Python monitor list operations (`performance.cache.*` config).
- Deduplicate Go PVC orphan detection to a single `ListPersistentVolumeClaims` call; add cache hit/miss Prometheus counters.

**Spec:** [docs/superpowers/specs/2026-05-31-pr-10-inventory-cache-design.md](docs/superpowers/specs/2026-05-31-pr-10-inventory-cache-design.md)

## Test plan

- [x] `make go-test` — all Go packages green
- [x] `make go-lint` — golangci-lint clean
- [x] `pytest tests/unit/test_inventory_cache.py tests/unit/test_monitor.py tests/unit/test_config.py` — pass
- [ ] `gh pr checks` — required CI green on head commit

## PR Checklist

- [x] **Scope:** Maps to remediation plan PR 10 (TTL inventory cache).
- [x] **Correctness:** Added/updated tests for cache hit/miss/expiry, wrapper call counts, PVC dedupe.
- [x] **Regression Safety:** Existing Go/Python tests pass.
- [ ] **CI:** All required GitHub Actions checks green on the PR head commit.
- [x] **Security:** Read-only cache layer; no new external dependencies.
- [x] **Reliability:** TTL expiry refreshes; max_size eviction; disabled cache passthrough.
- [x] **Performance:** Reduces duplicate list calls within TTL window.
- [x] **Docs:** Updated `config-compatibility.md`, `config.go.example`, `config.yaml.example`.
- [x] **Ops/Runbook:** Backout via `performance.cache.enabled: false` documented in spec.
- [x] **Verification Evidence:** Local `make go-test`, `make go-lint`, targeted pytest runs.
- [x] **Tracking:** Remediation plan updated (PR 9 Done, PR 10 In Progress).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a configurable in-process TTL inventory cache (enabled/ttl/max_size) for list operations across Go and Python, with cache hit/miss metrics.
* **Documentation**
  * Updated example configs, compatibility notes, and roadmap/plans describing cache keys, defaults, and wiring.
* **Tests**
  * New unit tests validating cache semantics, client integration, eviction/expiry, and metrics.
* **Bug Fix / Performance**
  * Reduced redundant list calls in orphan detection to a single scoped list operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->