### PR TITLE
PR 11: Watch-based incremental orphan reconcile

### DIFF
--- a/config.go.example
+++ b/config.go.example
@@ -20,7 +20,10 @@ truenas:
   # ca_file: /etc/truenas-monitor/truenas-ca.pem
 
 monitor:
-  scan_interval: 5m
+  reconcile_mode: poll   # poll | watch
+  scan_interval: 5m      # poll mode only
+  debounce: 30s          # watch mode only
+  truenas_poll_interval: 5m  # watch mode only
   orphan_threshold: 24h
   snapshot_retention: 720h
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -21,6 +21,9 @@ truenas:
 
 # Monitoring configuration (required)
 monitoring:
+  reconcile_mode: poll   # poll | watch
+  debounce: 30s          # watch mode: debounced reconcile quiet period
+  truenas_poll_interval: 5m  # watch mode: TrueNAS background refresh
   orphan_check_interval: 1h
   orphan_threshold: 24h
   snapshot:

--- a/docs/config-compatibility.md
+++ b/docs/config-compatibility.md
@@ -20,6 +20,7 @@ Go services and the Python library/CLI use **different YAML schemas**. A single 
 | In-cluster mode | `kubernetes.in_cluster` | `openshift.in_cluster` (boolean, defaults to false) |
 | CSI namespace | `kubernetes.namespace` | `openshift.namespace` |
 | Monitor tuning | `monitor.scan_interval`, `monitor.orphan_threshold`, `monitor.snapshot_retention` — **wired** in Go monitor and API | `monitoring.orphan_threshold`, `monitoring.snapshot.max_age` — **wired** in Python `Monitor.find_orphaned_resources()`; `monitoring.orphan_check_interval` still **not wired** (no background loop) |
+| Reconcile mode | `monitor.reconcile_mode` (`poll` default, `watch` opt-in), `monitor.debounce`, `monitor.truenas_poll_interval` — **wired** in Go monitor | `monitoring.reconcile_mode`, `monitoring.debounce`, `monitoring.truenas_poll_interval` — **wired** in `truenas-monitor watch` |
 | TrueNAS URL | `truenas.url` | `truenas.url` |
 | TrueNAS auth | `truenas.username`, `truenas.password` | `truenas.username`/`password` or `truenas.api_key` |
 | TLS insecure | `truenas.insecure` (default false) | `truenas.insecure` (default false) |

--- a/docs/superpowers/plans/2026-05-28-repo-health-remediation.md
+++ b/docs/superpowers/plans/2026-05-28-repo-health-remediation.md
@@ -99,7 +99,7 @@ Suggested worktree layout:
 - **Primary owner:** TBD
 - **Last updated:** 2026-05-31
 - **Last merged:** PR 10 TTL inventory cache [#60](https://github.com/tomazb/kubernetes-truenas-democratic-tool/pull/60) (2026-05-31, `0b9392e`)
-- **Next up:** PR 11 — Watch-based incremental reconcile
+- **Next up:** PR 12 — Performance budgets and cardinality docs
 
 ## Milestones
 
@@ -424,7 +424,7 @@ Suggested worktree layout:
 
 #### PR 11: Watch-Based Incremental Reconcile
 
-- **Status:** Ready for PR
+- **Status:** In Review
 - **Risk:** High
 - **Focus:** client-go SharedInformers for PV/PVC/VolumeSnapshot; debounced reconcile; Python watch hook integration.
 - **Branch/worktree:**
@@ -433,6 +433,7 @@ Suggested worktree layout:
 - **Depends on:** PR 10
 - **Spec/design:** `docs/superpowers/specs/2026-06-01-pr-11-watch-reconcile-design.md`
 - **Implementation plan:** `docs/superpowers/plans/2026-06-01-pr-11-watch-reconcile.md`
+- **PR URL:** https://github.com/tomazb/kubernetes-truenas-democratic-tool/pull/61
 - **Acceptance criteria:**
   - [x] Watch mode opt-in via config (`poll` default); full-scan fallback on resync failure.
   - [x] Debounced reconcile triggers detector without full poll on every event.

--- a/docs/superpowers/plans/2026-05-28-repo-health-remediation.md
+++ b/docs/superpowers/plans/2026-05-28-repo-health-remediation.md
@@ -424,16 +424,18 @@ Suggested worktree layout:
 
 #### PR 11: Watch-Based Incremental Reconcile
 
-- **Status:** Planned
+- **Status:** Ready for PR
 - **Risk:** High
 - **Focus:** client-go SharedInformers for PV/PVC/VolumeSnapshot; debounced reconcile; Python watch hook integration.
 - **Branch/worktree:**
   - Branch: `feature/pr-11-watch-reconcile`
   - Worktree: `.worktrees/pr-11-watch-reconcile`
 - **Depends on:** PR 10
+- **Spec/design:** `docs/superpowers/specs/2026-06-01-pr-11-watch-reconcile-design.md`
+- **Implementation plan:** `docs/superpowers/plans/2026-06-01-pr-11-watch-reconcile.md`
 - **Acceptance criteria:**
-  - [ ] Watch mode opt-in via config (`poll` default); full-scan fallback on resync failure.
-  - [ ] Debounced reconcile triggers detector without full poll on every event.
+  - [x] Watch mode opt-in via config (`poll` default); full-scan fallback on resync failure.
+  - [x] Debounced reconcile triggers detector without full poll on every event.
 
 #### PR 12: Performance Budgets and Cardinality Docs
 

--- a/docs/superpowers/plans/2026-06-01-pr-11-watch-reconcile.md
+++ b/docs/superpowers/plans/2026-06-01-pr-11-watch-reconcile.md
@@ -1,0 +1,114 @@
+# PR 11: Watch-Based Incremental Reconcile — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add opt-in watch mode with debounced orphan reconcile (Go monitor + Python `watch` CLI), periodic TrueNAS polling in watch mode, and full-scan recovery on watch failure.
+
+**Architecture:** New `go/pkg/reconcile/` controller with SharedInformers + debouncer + TN snapshot poller; Python `reconcile.py` + `truenas-monitor watch`; poll mode unchanged.
+
+**Tech Stack:** Go 1.24+, client-go informers, Python 3.10+, kubernetes watch client.
+
+**Spec:** [2026-06-01-pr-11-watch-reconcile-design.md](../specs/2026-06-01-pr-11-watch-reconcile-design.md)
+
+**Worktree:** `.worktrees/pr-11-watch-reconcile` on branch `feature/pr-11-watch-reconcile`
+
+---
+
+## Task 1: Go config — reconcile mode keys (TDD)
+
+**Files:**
+- Modify: `go/pkg/config/config.go`, `config_test.go`
+- Modify: `config.go.example`
+
+- [x] **Step 1:** Add `ReconcileMode`, `Debounce`, `TruenasPollInterval` to `MonitorConfig`; defaults `poll`, `30s`, `5m`
+- [x] **Step 2:** Validate `reconcile_mode` ∈ {poll, watch}; positive durations for watch-only fields
+- [x] **Step 3:** `go test ./pkg/config/... -v`
+
+## Task 2: Go debouncer package (TDD)
+
+**Files:**
+- Create: `go/pkg/reconcile/debounce.go`, `debounce_test.go`
+
+- [x] **Step 1:** Failing tests — single fire after quiet period; reset on retrigger; no fire after cancel
+- [x] **Step 2:** Implement with injectable clock
+- [x] **Step 3:** `go test ./pkg/reconcile/... -run Debounce -v`
+
+## Task 3: Go TrueNAS snapshot poller
+
+**Files:**
+- Create: `go/pkg/reconcile/truenas_poller.go`, `truenas_poller_test.go`
+
+- [x] **Step 1:** Poller updates mutex-protected volumes/snapshots on ticker
+- [x] **Step 2:** Test fake client called at interval; readers see latest snapshot
+- [x] **Step 3:** `go test ./pkg/reconcile/... -run Truenas -v`
+
+## Task 4: Go watch runner + informers
+
+**Files:**
+- Create: `go/pkg/reconcile/watch.go`, `watch_test.go`
+- Modify: `go/pkg/k8s/client.go` (only if lister helpers needed)
+
+- [x] **Step 1:** Build SharedInformerFactory for PV/PVC/VolumeSnapshot with existing label/driver filters
+- [x] **Step 2:** Event handlers call `debouncer.Trigger()`; increment watch event metric
+- [x] **Step 3:** Fake clientset / envtest-style unit tests for handler registration (minimal)
+
+## Task 5: Go reconcile controller
+
+**Files:**
+- Create: `go/pkg/reconcile/controller.go`, `controller_test.go`
+- Modify: `go/pkg/monitor/service.go`
+
+- [x] **Step 1:** `Controller.Run` — poll branch delegates to existing ticker loop; watch branch starts poller + informers
+- [x] **Step 2:** Debounced reconcile: invalidate inventory cache K8s keys, run detector, update metrics/last scan
+- [x] **Step 3:** Watch error → full scan once → restart watch (test with injected error channel)
+- [x] **Step 4:** Wire `go/cmd/monitor/main.go` from config
+
+## Task 6: Go metrics
+
+**Files:**
+- Modify: `go/pkg/metrics/exporter.go`, tests
+
+- [x] **Step 1:** Add gauge/counters per spec
+- [x] **Step 2:** Controller sets mode gauge on start
+
+## Task 7: Python config + validation
+
+**Files:**
+- Modify: `python/truenas_storage_monitor/config.py`, `tests/unit/test_config.py`
+- Modify: `config.yaml.example`
+
+- [x] **Step 1:** Properties `reconcile_mode`, `debounce`, `truenas_poll_interval`
+- [x] **Step 2:** Validation tests mirror Go rules
+
+## Task 8: Python WatchReconciler (TDD)
+
+**Files:**
+- Create: `python/truenas_storage_monitor/reconcile.py`, `tests/unit/test_reconcile.py`
+
+- [x] **Step 1:** Debounce tests with mock clock/timer
+- [x] **Step 2:** TN poller thread + snapshot
+- [x] **Step 3:** K8s watch loops (mock streams) trigger single reconcile per burst
+- [x] **Step 4:** Watch failure runs full `find_orphaned_resources` then restarts watches
+
+## Task 9: Python CLI `watch` command
+
+**Files:**
+- Modify: `python/truenas_storage_monitor/cli.py`, `tests/unit/test_cli.py`
+
+- [x] **Step 1:** `truenas-monitor watch` runs reconciler until SIGINT
+- [x] **Step 2:** Rejects if `reconcile_mode=poll` with clear message (or honors CLI `--mode` override documented in help)
+
+## Task 10: Docs and plan tracking
+
+**Files:**
+- Modify: `docs/config-compatibility.md`, `docs/superpowers/plans/2026-05-28-repo-health-remediation.md`
+
+- [x] **Step 1:** Document new keys and poll vs watch semantics
+- [ ] **Step 2:** Link spec + PR URL when opened
+
+## Task 11: Verification gate
+
+- [x] `make go-test && make go-lint && cd go && go vet ./...`
+- [x] `make python-test` (106 passed, coverage 77.9%)
+- [x] Python lint on touched files; project-wide flake8 has pre-existing E501 in `truenas_client.py`
+- [ ] Manual note in PR: watch mode smoke on kind (optional)

--- a/docs/superpowers/plans/2026-06-01-pr-11-watch-reconcile.md
+++ b/docs/superpowers/plans/2026-06-01-pr-11-watch-reconcile.md
@@ -104,7 +104,7 @@
 - Modify: `docs/config-compatibility.md`, `docs/superpowers/plans/2026-05-28-repo-health-remediation.md`
 
 - [x] **Step 1:** Document new keys and poll vs watch semantics
-- [ ] **Step 2:** Link spec + PR URL when opened
+- [x] **Step 2:** Link spec + PR URL when opened — https://github.com/tomazb/kubernetes-truenas-democratic-tool/pull/61
 
 ## Task 11: Verification gate
 

--- a/docs/superpowers/specs/2026-06-01-pr-11-watch-reconcile-design.md
+++ b/docs/superpowers/specs/2026-06-01-pr-11-watch-reconcile-design.md
@@ -1,0 +1,154 @@
+# PR 11: Watch-Based Incremental Reconcile — Design Spec
+
+**Date:** 2026-06-01  
+**Plan item:** [Remediation plan PR 11](../plans/2026-05-28-repo-health-remediation.md)  
+**Milestone:** M4 — Scale and Product Depth (Stage 2 foundation)  
+**Depends on:** PR 10 (TTL inventory cache, merged)
+
+## Problem statement and scope
+
+PR 10 reduced repeated **list** traffic via TTL cache, but the Go monitor and Python library still drive orphan detection on a fixed **poll** loop (ticker / one-shot CLI). On active clusters, storage objects change between scan intervals; operators want fresher K8s-side detection without listing the full inventory on every watch notification.
+
+**In scope:**
+
+- Opt-in `watch` reconcile mode (`poll` remains default) in Go monitor and Python long-running CLI
+- Go: `client-go` SharedInformers for PV, PVC, and VolumeSnapshot (democratic-csi filtered)
+- Debounced reconcile: coalesce watch events; run orphan detector once per debounce window
+- TrueNAS: separate periodic poll in watch mode; debounced K8s reconcile uses last TN snapshot between polls
+- Watch failure: immediate full poll reconcile, then restart watch
+- Invalidate or bypass PR 10 inventory cache for K8s keys on debounced reconcile (TrueNAS lists follow TN poll / full-scan rules)
+- Prometheus metrics for mode, watch events, reconcile triggers, TN poll age
+- Python parity: equivalent config keys, debounced reconcile, `truenas-monitor watch` command
+- Docs: `config-compatibility.md`, `config.go.example`, `config.yaml.example`
+
+**Out of scope:**
+
+- API server watch mode (stays on-demand list + cache; no long-running informers in API process)
+- TrueNAS streaming watch (not available)
+- Redis / shared informer cache across replicas (ARCHITECTURE future state)
+- Performance budget enforcement (PR 12)
+- Horizontal scaling / leader election for multiple monitor replicas
+
+## Decisions (brainstorming)
+
+| Topic | Choice |
+|-------|--------|
+| Vertical slice | Full parity: Go monitor + Python watch CLI with aligned config |
+| TrueNAS in watch mode | Separate `truenas_poll_interval`; debounced K8s reconcile uses cached TN snapshot between polls |
+| Watch disconnect / resync failure | Immediate full poll reconcile, then restart watch |
+
+## Current vs target behavior
+
+| Surface | Current | Target |
+|---------|---------|--------|
+| Go monitor loop | Ticker → full `performScan` (lists + detector) | `poll`: unchanged; `watch`: informers + debounced reconcile |
+| Go K8s reads on change | N/A (poll only) | Informer listers; optional cache invalidation before detector |
+| Go TrueNAS reads | Every scan | Watch mode: periodic background poll + snapshot for reconcile |
+| Go config | `monitor.scan_interval` only | Add `reconcile_mode`, `debounce`, `truenas_poll_interval` |
+| Python CLI | One-shot `orphans` / `analyze` | Add long-running `watch` subcommand when `reconcile_mode=watch` |
+| Python K8s | `watch_*` generators exist but unused by monitor | Wired into debounced reconcile loop |
+| Metrics | Scan / list phase histograms (PR 9) | Add watch/reconcile counters and mode gauge |
+
+## Technical approach
+
+### Config (aligned cross-stack)
+
+**Go** (`monitor` section):
+
+```yaml
+monitor:
+  reconcile_mode: poll          # poll | watch
+  scan_interval: 5m             # poll mode only
+  debounce: 30s                 # watch mode: min gap between reconciles
+  truenas_poll_interval: 5m     # watch mode: TrueNAS background refresh
+  orphan_threshold: 24h
+  snapshot_retention: 30d
+```
+
+**Python** (`monitoring` section):
+
+```yaml
+monitoring:
+  reconcile_mode: poll
+  debounce: 30s
+  truenas_poll_interval: 5m
+  orphan_threshold: 24h
+```
+
+Validation: reject unknown `reconcile_mode`; require `debounce` / `truenas_poll_interval` > 0 when mode is `watch`.
+
+### Go architecture
+
+New package `go/pkg/reconcile/`:
+
+1. **`Controller`** — owns mode, debouncer, TN snapshot store (mutex-protected), and `Run(ctx)`.
+2. **`WatchRunner`** — builds `SharedInformerFactory` with resync period 0 (rely on API resync + our failure handler). Registers PV, PVC, VolumeSnapshot informers with democratic-csi / namespace filters matching `k8s.Client` list behavior.
+3. **`Debouncer`** — `Trigger()` resets timer; on fire calls `reconcileFn` once.
+4. **`reconcileFn`** — invalidates K8s inventory cache keys (if cache enabled), runs existing `orphan.Detector.Detect` (lists still work via informer-backed client or explicit list — prefer lister adapter to avoid duplicate API calls where practical).
+5. **`TrueNASPoller`** — goroutine ticker at `truenas_poll_interval`; updates in-memory TN volumes/snapshots snapshot used by detector wrapper or pre-list injection.
+6. **Failure handler** — on informer watch error channel: log, run one full `performScan` equivalent (poll path), clear debouncer, restart informers.
+
+Wire in `go/cmd/monitor/main.go`: if `reconcile_mode == watch`, use `reconcile.Controller` instead of ticker-only `monitorLoop`; poll mode keeps current `Service.monitorLoop`.
+
+**Cache interaction (PR 10):** On debounced reconcile, invalidate `k8s_pvs`, `k8s_pvcs:*`, `k8s_snapshots:*` keys. TN data served from poller snapshot until next TN poll (no per-event TN list).
+
+### Python architecture
+
+New module `python/truenas_storage_monitor/reconcile.py`:
+
+1. **`WatchReconciler`** — threads: TN poller, K8s watch multiplex (PV + PVC + VolumeSnapshot using existing client patterns), debounce timer (`threading.Timer`).
+2. **`truenas-monitor watch`** — Click command: load config, run reconciler until SIGINT, log orphan counts / scan duration like Go.
+3. Config properties: `reconcile_mode`, `debounce`, `truenas_poll_interval`.
+4. One-shot CLI commands remain poll-based (unchanged behavior).
+
+### Metrics
+
+| Metric | Type | Labels |
+|--------|------|--------|
+| `truenas_monitor_reconcile_mode` | Gauge | `mode=poll\|watch` |
+| `truenas_monitor_watch_events_total` | Counter | `resource=pv\|pvc\|snapshot` |
+| `truenas_monitor_reconcile_triggers_total` | Counter | `trigger=debounce\|full_scan\|poll_tick` |
+| `truenas_monitor_truenas_snapshot_age_seconds` | Gauge | — |
+
+Python: same names when `metrics.enabled`.
+
+### Alternatives considered
+
+| Approach | Verdict |
+|----------|---------|
+| Watch only in Go; Python docs-only | Rejected — user chose full parity |
+| Refresh TrueNAS on every debounced K8s event | Rejected — too much TN API load |
+| Fall back to poll for process lifetime on watch error | Rejected — prefer immediate full scan + restart watch |
+| Informers inside `k8s.Client` | Rejected — keep client list-based; reconcile package owns informers |
+
+## Risk, failure modes, and mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Informer memory for large clusters | Document supported cardinality; PR 12 budgets |
+| Missed events during reconnect | Full scan on watch failure before restart |
+| Stale TN snapshot between polls | Configurable `truenas_poll_interval`; metric for snapshot age |
+| Debounce delays urgent orphan detection | Tunable `debounce`; document tradeoff |
+| Python GIL / thread safety | Mutex around TN snapshot and reconcile entry |
+| Duplicate work with TTL cache | Invalidate K8s keys on debounced reconcile |
+
+## Test strategy
+
+```bash
+cd go && go test ./pkg/reconcile/... ./pkg/monitor/... -v
+cd python && pytest tests/unit/test_reconcile.py tests/unit/test_monitor.py -v
+make go-test && make python-test
+make go-lint && make python-lint
+```
+
+**Go:** debouncer unit tests (fake clock); controller triggers detector once per burst; watch failure invokes full scan mock; TN poller updates snapshot.
+
+**Python:** debounce coalescing; watch command exits on signal; config validation for modes.
+
+**Integration (optional manual):** `reconcile_mode: watch` against kind cluster; verify metrics increment on PVC create/delete.
+
+## Rollout and backout
+
+**Rollout:** Deploy with `reconcile_mode: poll` (default). Enable watch per environment after validating metrics and TN poll interval.
+
+**Backout:** Set `reconcile_mode: poll` or revert PR; no schema migration.

--- a/go/cmd/monitor/main.go
+++ b/go/cmd/monitor/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/logging"
 	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/metrics"
 	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/monitor"
+	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/reconcile"
 	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/truenas"
 	"go.uber.org/zap"
 )
@@ -89,15 +90,34 @@ func main() {
 
 	inventoryCache := inventorycache.NewFromConfig(cfg.Performance, metricsExporter)
 	k8sClient = inventorycache.WrapK8sClient(k8sClient, inventoryCache)
-	truenasClient = inventorycache.WrapTrueNASClient(truenasClient, inventoryCache)
+
+	truenasPollClient := truenasClient
+	truenasForDetector := inventorycache.WrapTrueNASClient(truenasClient, inventoryCache)
+	var tnPoller *reconcile.TruenasPoller
+	if cfg.Monitor.ReconcileMode == config.ReconcileModeWatch {
+		tnPoller = reconcile.NewTruenasPoller(truenasPollClient, cfg.Monitor.TruenasPollInterval)
+		truenasForDetector = reconcile.WrapTruenasWithSnapshot(truenasPollClient, tnPoller)
+	}
 
 	// Initialize monitor service
 	monitorService, err := monitor.NewService(monitor.Config{
-		K8sClient:         k8sClient,
-		TruenasClient:     truenasClient,
-		MetricsExporter:   metricsExporter,
-		Logger:            logger,
-		ScanInterval:      cfg.Monitor.ScanInterval,
+		K8sClient:           k8sClient,
+		TruenasClient:       truenasForDetector,
+		TruenasPollClient:   truenasPollClient,
+		TruenasPoller:       tnPoller,
+		MetricsExporter:     metricsExporter,
+		Logger:              logger,
+		ScanInterval:        cfg.Monitor.ScanInterval,
+		ReconcileMode:       cfg.Monitor.ReconcileMode,
+		Debounce:            cfg.Monitor.Debounce,
+		TruenasPollInterval: cfg.Monitor.TruenasPollInterval,
+		K8sConfig: k8s.Config{
+			Kubeconfig: cfg.Kubernetes.Kubeconfig,
+			Namespace:  cfg.Kubernetes.Namespace,
+			InCluster:  cfg.Kubernetes.InCluster,
+		},
+		Namespace:         cfg.Kubernetes.Namespace,
+		InventoryCache:    inventoryCache,
 		OrphanThreshold:   cfg.Monitor.OrphanThreshold,
 		SnapshotRetention: cfg.Monitor.SnapshotRetention,
 	})
@@ -119,11 +139,20 @@ func main() {
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 
 	orphanThreshold, snapshotRetention := monitorService.DetectorThresholds()
-	logger.Info("Monitor service started successfully",
-		zap.Duration("scan_interval", cfg.Monitor.ScanInterval),
+	startFields := []zap.Field{
+		zap.String("reconcile_mode", cfg.Monitor.ReconcileMode),
 		zap.Duration("orphan_threshold", orphanThreshold),
 		zap.Duration("snapshot_retention", snapshotRetention),
-	)
+	}
+	if cfg.Monitor.ReconcileMode == config.ReconcileModeWatch {
+		startFields = append(startFields,
+			zap.Duration("debounce", cfg.Monitor.Debounce),
+			zap.Duration("truenas_poll_interval", cfg.Monitor.TruenasPollInterval),
+		)
+	} else {
+		startFields = append(startFields, zap.Duration("scan_interval", cfg.Monitor.ScanInterval))
+	}
+	logger.Info("Monitor service started successfully", startFields...)
 	<-sigChan
 
 	logger.Info("Shutting down monitor service...")

--- a/go/go.mod
+++ b/go/go.mod
@@ -14,6 +14,7 @@ require (
 require (
 	github.com/go-resty/resty/v2 v2.16.5
 	github.com/google/uuid v1.6.0
+	github.com/prometheus/client_model v0.5.0
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/zap v1.27.0
 	golang.org/x/time v0.14.0
@@ -43,6 +44,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/gnostic-models v0.6.9 // indirect
+	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/imdario/mergo v0.3.6 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
@@ -57,7 +59,6 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect

--- a/go/pkg/config/config.go
+++ b/go/pkg/config/config.go
@@ -39,11 +39,19 @@ type TrueNASConfig struct {
 	CAFile   string `yaml:"ca_file"`
 }
 
+const (
+	ReconcileModePoll  = "poll"
+	ReconcileModeWatch = "watch"
+)
+
 // MonitorConfig holds monitoring settings
 type MonitorConfig struct {
-	ScanInterval     time.Duration `yaml:"scan_interval"`
-	OrphanThreshold  time.Duration `yaml:"orphan_threshold"`
-	SnapshotRetention time.Duration `yaml:"snapshot_retention"`
+	ReconcileMode       string        `yaml:"reconcile_mode"`
+	ScanInterval        time.Duration `yaml:"scan_interval"`
+	Debounce            time.Duration `yaml:"debounce"`
+	TruenasPollInterval time.Duration `yaml:"truenas_poll_interval"`
+	OrphanThreshold     time.Duration `yaml:"orphan_threshold"`
+	SnapshotRetention   time.Duration `yaml:"snapshot_retention"`
 }
 
 // MetricsConfig holds metrics export settings
@@ -104,9 +112,12 @@ func Load(path string) (*Config, error) {
 			Timeout: "30s",
 		},
 		Monitor: MonitorConfig{
-			ScanInterval:      5 * time.Minute,
-			OrphanThreshold:   24 * time.Hour,
-			SnapshotRetention: 30 * 24 * time.Hour,
+			ReconcileMode:       ReconcileModePoll,
+			ScanInterval:        5 * time.Minute,
+			Debounce:            30 * time.Second,
+			TruenasPollInterval: 5 * time.Minute,
+			OrphanThreshold:     24 * time.Hour,
+			SnapshotRetention:   30 * 24 * time.Hour,
 		},
 		Metrics: MetricsConfig{
 			Enabled: true,
@@ -156,6 +167,7 @@ func Load(path string) (*Config, error) {
 	}
 
 	config.applyPerformanceDefaults()
+	config.applyMonitorDefaults()
 
 	// Validate configuration only if file exists
 	if fileExists {
@@ -183,6 +195,18 @@ func (c *Config) applyPerformanceDefaults() {
 	}
 	if c.Performance.Cache.MaxSize == 0 {
 		c.Performance.Cache.MaxSize = 1000
+	}
+}
+
+func (c *Config) applyMonitorDefaults() {
+	if c.Monitor.ReconcileMode == "" {
+		c.Monitor.ReconcileMode = ReconcileModePoll
+	}
+	if c.Monitor.Debounce == 0 {
+		c.Monitor.Debounce = 30 * time.Second
+	}
+	if c.Monitor.TruenasPollInterval == 0 {
+		c.Monitor.TruenasPollInterval = 5 * time.Minute
 	}
 }
 
@@ -244,12 +268,28 @@ func (c *Config) validate() error {
 	}
 
 	// Monitor validation
-	if c.Monitor.ScanInterval < time.Minute {
-		return fmt.Errorf("monitor.scan_interval must be at least 1 minute")
+	mode := strings.ToLower(strings.TrimSpace(c.Monitor.ReconcileMode))
+	if mode != ReconcileModePoll && mode != ReconcileModeWatch {
+		return fmt.Errorf("monitor.reconcile_mode must be %q or %q", ReconcileModePoll, ReconcileModeWatch)
+	}
+	c.Monitor.ReconcileMode = mode
+
+	if mode == ReconcileModePoll {
+		if c.Monitor.ScanInterval < time.Minute {
+			return fmt.Errorf("monitor.scan_interval must be at least 1 minute")
+		}
+		if c.Monitor.ScanInterval > 24*time.Hour {
+			return fmt.Errorf("monitor.scan_interval must not exceed 24 hours")
+		}
 	}
 
-	if c.Monitor.ScanInterval > 24*time.Hour {
-		return fmt.Errorf("monitor.scan_interval must not exceed 24 hours")
+	if mode == ReconcileModeWatch {
+		if c.Monitor.Debounce < time.Second {
+			return fmt.Errorf("monitor.debounce must be at least 1 second")
+		}
+		if c.Monitor.TruenasPollInterval < time.Minute {
+			return fmt.Errorf("monitor.truenas_poll_interval must be at least 1 minute")
+		}
 	}
 
 	if c.Monitor.OrphanThreshold < time.Hour {

--- a/go/pkg/config/config_test.go
+++ b/go/pkg/config/config_test.go
@@ -37,7 +37,10 @@ truenas:
 				assert.Equal(t, "admin", cfg.TrueNAS.Username)
 				assert.Equal(t, "secret123", cfg.TrueNAS.Password)
 				assert.Equal(t, "30s", cfg.TrueNAS.Timeout)
+				assert.Equal(t, ReconcileModePoll, cfg.Monitor.ReconcileMode)
 				assert.Equal(t, 5*time.Minute, cfg.Monitor.ScanInterval)
+				assert.Equal(t, 30*time.Second, cfg.Monitor.Debounce)
+				assert.Equal(t, 5*time.Minute, cfg.Monitor.TruenasPollInterval)
 				assert.Equal(t, 24*time.Hour, cfg.Monitor.OrphanThreshold)
 				assert.True(t, cfg.Metrics.Enabled)
 				assert.Equal(t, 8080, cfg.Metrics.Port)
@@ -135,6 +138,50 @@ monitor:
 			wantErr: true,
 		},
 		{
+			name: "watch mode config",
+			configYAML: `
+truenas:
+  url: https://truenas.example.com
+  username: admin
+  password: secret123
+monitor:
+  reconcile_mode: watch
+  debounce: 45s
+  truenas_poll_interval: 10m
+`,
+			wantErr: false,
+			validate: func(t *testing.T, cfg *Config) {
+				assert.Equal(t, ReconcileModeWatch, cfg.Monitor.ReconcileMode)
+				assert.Equal(t, 45*time.Second, cfg.Monitor.Debounce)
+				assert.Equal(t, 10*time.Minute, cfg.Monitor.TruenasPollInterval)
+			},
+		},
+		{
+			name: "invalid reconcile mode",
+			configYAML: `
+truenas:
+  url: https://truenas.example.com
+  username: admin
+  password: secret123
+monitor:
+  reconcile_mode: stream
+`,
+			wantErr: true,
+		},
+		{
+			name: "watch mode debounce too short",
+			configYAML: `
+truenas:
+  url: https://truenas.example.com
+  username: admin
+  password: secret123
+monitor:
+  reconcile_mode: watch
+  debounce: 100ms
+`,
+			wantErr: true,
+		},
+		{
 			name: "invalid timeout format",
 			configYAML: `
 truenas:
@@ -190,7 +237,10 @@ func TestLoadNonExistentFile(t *testing.T) {
 	assert.Equal(t, "democratic-csi", cfg.Kubernetes.Namespace)
 	assert.True(t, cfg.Kubernetes.InCluster)
 	assert.Equal(t, "30s", cfg.TrueNAS.Timeout)
+	assert.Equal(t, ReconcileModePoll, cfg.Monitor.ReconcileMode)
 	assert.Equal(t, 5*time.Minute, cfg.Monitor.ScanInterval)
+	assert.Equal(t, 30*time.Second, cfg.Monitor.Debounce)
+	assert.Equal(t, 5*time.Minute, cfg.Monitor.TruenasPollInterval)
 	assert.Equal(t, 24*time.Hour, cfg.Monitor.OrphanThreshold)
 	assert.True(t, cfg.Metrics.Enabled)
 	assert.Equal(t, 8080, cfg.Metrics.Port)
@@ -214,8 +264,11 @@ func TestValidate(t *testing.T) {
 					Timeout:  "30s",
 				},
 				Monitor: MonitorConfig{
-					ScanInterval:    5 * time.Minute,
-					OrphanThreshold: 24 * time.Hour,
+					ReconcileMode:       ReconcileModePoll,
+					ScanInterval:        5 * time.Minute,
+					OrphanThreshold:     24 * time.Hour,
+					Debounce:            30 * time.Second,
+					TruenasPollInterval: 5 * time.Minute,
 				},
 				Metrics: MetricsConfig{
 					Port: 8080,
@@ -240,6 +293,46 @@ func TestValidate(t *testing.T) {
 				},
 			},
 			wantErr: false,
+		},
+		{
+			name: "watch mode requires debounce",
+			config: &Config{
+				TrueNAS: TrueNASConfig{
+					URL:      "https://truenas.example.com",
+					Username: "admin",
+					Password: "secret123",
+					Timeout:  "30s",
+				},
+				Monitor: MonitorConfig{
+					ReconcileMode:       ReconcileModeWatch,
+					Debounce:            100 * time.Millisecond,
+					TruenasPollInterval: 5 * time.Minute,
+					OrphanThreshold:     24 * time.Hour,
+				},
+				Metrics: MetricsConfig{
+					Port: 8080,
+					Path: "/metrics",
+				},
+				Logging: LoggingConfig{
+					Level:    "info",
+					Encoding: "json",
+				},
+				Security: SecurityConfig{
+					TLSMinVersion:  "1.3",
+					RateLimitRPS:   100,
+					AllowedOrigins: []string{"*"},
+					SessionTimeout: 24 * time.Hour,
+				},
+				Performance: PerformanceConfig{
+					Cache: CacheConfig{
+						Enabled: true,
+						TTL:     5 * time.Minute,
+						MaxSize: 1000,
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "monitor.debounce must be at least 1 second",
 		},
 		{
 			name: "cache ttl too short",
@@ -360,6 +453,7 @@ func TestValidate(t *testing.T) {
 					Timeout:  "30s",
 				},
 				Monitor: MonitorConfig{
+					ReconcileMode:   ReconcileModePoll,
 					ScanInterval:    30 * time.Second,
 					OrphanThreshold: 24 * time.Hour,
 				},
@@ -381,6 +475,7 @@ func TestValidate(t *testing.T) {
 					Timeout:  "30s",
 				},
 				Monitor: MonitorConfig{
+					ReconcileMode:   ReconcileModePoll,
 					ScanInterval:    25 * time.Hour,
 					OrphanThreshold: 24 * time.Hour,
 				},
@@ -502,6 +597,7 @@ func TestValidate(t *testing.T) {
 			}
 
 			cfg.applyPerformanceDefaults()
+			cfg.applyMonitorDefaults()
 			err := cfg.validate()
 
 			if tt.wantErr {
@@ -530,7 +626,10 @@ func TestConfigDefaults(t *testing.T) {
 	assert.Equal(t, "30s", cfg.TrueNAS.Timeout)
 
 	// Monitor defaults
+	assert.Equal(t, ReconcileModePoll, cfg.Monitor.ReconcileMode)
 	assert.Equal(t, 5*time.Minute, cfg.Monitor.ScanInterval)
+	assert.Equal(t, 30*time.Second, cfg.Monitor.Debounce)
+	assert.Equal(t, 5*time.Minute, cfg.Monitor.TruenasPollInterval)
 	assert.Equal(t, 24*time.Hour, cfg.Monitor.OrphanThreshold)
 	assert.Equal(t, 30*24*time.Hour, cfg.Monitor.SnapshotRetention)
 
@@ -626,8 +725,11 @@ func validConfigForValidate(t *testing.T) *Config {
 			Timeout:  "30s",
 		},
 		Monitor: MonitorConfig{
-			ScanInterval:    5 * time.Minute,
-			OrphanThreshold: 24 * time.Hour,
+			ReconcileMode:       ReconcileModePoll,
+			ScanInterval:        5 * time.Minute,
+			Debounce:            30 * time.Second,
+			TruenasPollInterval: 5 * time.Minute,
+			OrphanThreshold:     24 * time.Hour,
 		},
 		Metrics: MetricsConfig{
 			Port: 8080,

--- a/go/pkg/inventorycache/cache.go
+++ b/go/pkg/inventorycache/cache.go
@@ -141,6 +141,33 @@ func (c *Cache) set(key string, value any) {
 	}
 }
 
+// InvalidateAll clears every cached entry.
+func (c *Cache) InvalidateAll() {
+	if c == nil || !c.enabled {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries = make(map[string]entry)
+}
+
+// InvalidateK8sInventory removes cached Kubernetes list keys.
+func (c *Cache) InvalidateK8sInventory() {
+	if c == nil || !c.enabled {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for key := range c.entries {
+		if len(key) >= 4 && key[:4] == "k8s_" {
+			delete(c.entries, key)
+		}
+	}
+}
+
 // NamespaceKey builds a cache key with optional namespace scope.
 func NamespaceKey(prefix, namespace string) string {
 	if namespace == "" {

--- a/go/pkg/inventorycache/cache_test.go
+++ b/go/pkg/inventorycache/cache_test.go
@@ -8,6 +8,39 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestCache_InvalidateK8sInventory(t *testing.T) {
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	cache := NewCache(Config{
+		Enabled: true,
+		TTL:     time.Minute,
+		MaxSize: 10,
+		Now:     func() time.Time { return now },
+	})
+
+	_, _ = GetOrLoad(cache, "k8s_pvs", "k8s_pvs", func() (string, error) { return "a", nil })
+	_, _ = GetOrLoad(cache, "truenas_datasets", "truenas_datasets", func() (string, error) {
+		return "b", nil
+	})
+
+	cache.InvalidateK8sInventory()
+
+	var loads int32
+	_, err := GetOrLoad(cache, "k8s_pvs", "k8s_pvs", func() (string, error) {
+		atomic.AddInt32(&loads, 1)
+		return "a2", nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, int32(1), loads)
+
+	var tnLoads int32
+	_, err = GetOrLoad(cache, "truenas_datasets", "truenas_datasets", func() (string, error) {
+		atomic.AddInt32(&tnLoads, 1)
+		return "b", nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, int32(0), tnLoads)
+}
+
 func TestCache_GetOrLoad_HitAndMiss(t *testing.T) {
 	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
 	var hits, misses int64

--- a/go/pkg/k8s/client.go
+++ b/go/pkg/k8s/client.go
@@ -3,16 +3,12 @@ package k8s
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/util/homedir"
 	"k8s.io/client-go/util/retry"
 
 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
@@ -93,59 +89,9 @@ type Config struct {
 
 // NewClient creates a new Kubernetes client
 func NewClient(config Config) (Client, error) {
-	// Set defaults
-	if config.Timeout == 0 {
-		config.Timeout = 30 * time.Second
-	}
-	if config.RetryAttempts == 0 {
-		config.RetryAttempts = 3
-	}
-	if config.QPS == 0 {
-		config.QPS = 50.0
-	}
-	if config.Burst == 0 {
-		config.Burst = 100
-	}
-
-	var restConfig *rest.Config
-	var err error
-
-	if config.InCluster {
-		// Use in-cluster configuration
-		restConfig, err = rest.InClusterConfig()
-		if err != nil {
-			return nil, fmt.Errorf("failed to create in-cluster config: %w", err)
-		}
-	} else {
-		// Use kubeconfig file
-		kubeconfigPath := config.Kubeconfig
-		if kubeconfigPath == "" {
-			if home := homedir.HomeDir(); home != "" {
-				kubeconfigPath = filepath.Join(home, ".kube", "config")
-			}
-		}
-
-		restConfig, err = clientcmd.BuildConfigFromFlags("", kubeconfigPath)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create config from kubeconfig: %w", err)
-		}
-	}
-
-	// Configure connection settings
-	restConfig.Timeout = config.Timeout
-	restConfig.QPS = config.QPS
-	restConfig.Burst = config.Burst
-
-	// Create clientset
-	clientset, err := kubernetes.NewForConfig(restConfig)
+	clientset, snapshotClient, err := NewKubernetesClients(config)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create clientset: %w", err)
-	}
-
-	// Create snapshot client
-	snapshotClient, err := snapshotclient.NewForConfig(restConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create snapshot client: %w", err)
+		return nil, err
 	}
 
 	// Initialize logger

--- a/go/pkg/k8s/clientset.go
+++ b/go/pkg/k8s/clientset.go
@@ -1,0 +1,78 @@
+package k8s
+
+import (
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/homedir"
+
+	snapshotclient "github.com/kubernetes-csi/external-snapshotter/client/v6/clientset/versioned"
+)
+
+const defaultClientTimeout = 30 * time.Second
+
+func buildRESTConfig(config Config) (*rest.Config, error) {
+	if config.Timeout == 0 {
+		config.Timeout = defaultClientTimeout
+	}
+	if config.RetryAttempts == 0 {
+		config.RetryAttempts = 3
+	}
+	if config.QPS == 0 {
+		config.QPS = 50.0
+	}
+	if config.Burst == 0 {
+		config.Burst = 100
+	}
+
+	var restConfig *rest.Config
+	var err error
+
+	if config.InCluster {
+		restConfig, err = rest.InClusterConfig()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create in-cluster config: %w", err)
+		}
+	} else {
+		kubeconfigPath := config.Kubeconfig
+		if kubeconfigPath == "" {
+			if home := homedir.HomeDir(); home != "" {
+				kubeconfigPath = filepath.Join(home, ".kube", "config")
+			}
+		}
+
+		restConfig, err = clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create config from kubeconfig: %w", err)
+		}
+	}
+
+	restConfig.Timeout = config.Timeout
+	restConfig.QPS = config.QPS
+	restConfig.Burst = config.Burst
+	return restConfig, nil
+}
+
+// NewKubernetesClients creates typed clientsets for informers and watches.
+func NewKubernetesClients(config Config) (kubernetes.Interface, snapshotclient.Interface, error) {
+	restConfig, err := buildRESTConfig(config)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create clientset: %w", err)
+	}
+
+	snapshotClient, err := snapshotclient.NewForConfig(restConfig)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create snapshot client: %w", err)
+	}
+
+	return clientset, snapshotClient, nil
+}

--- a/go/pkg/metrics/exporter.go
+++ b/go/pkg/metrics/exporter.go
@@ -27,6 +27,10 @@ type Exporter struct {
 	listDurationHist       *prometheus.HistogramVec
 	cacheHits              *prometheus.CounterVec
 	cacheMisses            *prometheus.CounterVec
+	reconcileMode          *prometheus.GaugeVec
+	watchEvents            *prometheus.CounterVec
+	reconcileTriggers      *prometheus.CounterVec
+	truenasSnapshotAge     prometheus.Gauge
 	totalPVs               prometheus.Gauge
 	totalPVCs              prometheus.Gauge
 	totalSnapshots         prometheus.Gauge
@@ -92,6 +96,26 @@ func NewExporter(config Config) *Exporter {
 		Help: "Inventory cache misses by operation",
 	}, []string{"operation"})
 
+	reconcileMode := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "truenas_monitor_reconcile_mode",
+		Help: "Active reconcile mode (1 for active mode)",
+	}, []string{"mode"})
+
+	watchEvents := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "truenas_monitor_watch_events_total",
+		Help: "Kubernetes watch events received",
+	}, []string{"resource"})
+
+	reconcileTriggers := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "truenas_monitor_reconcile_triggers_total",
+		Help: "Orphan reconcile runs by trigger",
+	}, []string{"trigger"})
+
+	truenasSnapshotAge := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "truenas_monitor_truenas_snapshot_age_seconds",
+		Help: "Age of the last successful TrueNAS inventory poll in watch mode",
+	})
+
 	totalPVs := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "truenas_monitor_pvs_total",
 		Help: "Total number of persistent volumes",
@@ -127,6 +151,10 @@ func NewExporter(config Config) *Exporter {
 		listDurationHist,
 		cacheHits,
 		cacheMisses,
+		reconcileMode,
+		watchEvents,
+		reconcileTriggers,
+		truenasSnapshotAge,
 		totalPVs,
 		totalPVCs,
 		totalSnapshots,
@@ -163,6 +191,10 @@ func NewExporter(config Config) *Exporter {
 		listDurationHist:       listDurationHist,
 		cacheHits:              cacheHits,
 		cacheMisses:            cacheMisses,
+		reconcileMode:          reconcileMode,
+		watchEvents:            watchEvents,
+		reconcileTriggers:      reconcileTriggers,
+		truenasSnapshotAge:     truenasSnapshotAge,
 		totalPVs:               totalPVs,
 		totalPVCs:              totalPVCs,
 		totalSnapshots:         totalSnapshots,
@@ -222,6 +254,32 @@ func (e *Exporter) ObserveScanDuration(duration float64) {
 // ObserveListPhaseDuration records a list operation duration for a detection phase
 func (e *Exporter) ObserveListPhaseDuration(phase string, duration float64) {
 	e.listDurationHist.WithLabelValues(phase).Observe(duration)
+}
+
+// SetReconcileMode marks which reconcile mode is active.
+func (e *Exporter) SetReconcileMode(mode string) {
+	for _, candidate := range []string{"poll", "watch"} {
+		value := 0.0
+		if candidate == mode {
+			value = 1
+		}
+		e.reconcileMode.WithLabelValues(candidate).Set(value)
+	}
+}
+
+// RecordWatchEvent increments watch event counters.
+func (e *Exporter) RecordWatchEvent(resource string) {
+	e.watchEvents.WithLabelValues(resource).Inc()
+}
+
+// IncReconcileTrigger increments reconcile trigger counters.
+func (e *Exporter) IncReconcileTrigger(trigger string) {
+	e.reconcileTriggers.WithLabelValues(trigger).Inc()
+}
+
+// SetTruenasSnapshotAge sets the TrueNAS snapshot age gauge in seconds.
+func (e *Exporter) SetTruenasSnapshotAge(ageSeconds float64) {
+	e.truenasSnapshotAge.Set(ageSeconds)
 }
 
 // RecordInventoryCacheAccess increments cache hit or miss counters.

--- a/go/pkg/metrics/exporter_test.go
+++ b/go/pkg/metrics/exporter_test.go
@@ -73,3 +73,45 @@ func TestExporter_RecordInventoryCacheAccess(t *testing.T) {
 	require.Equal(t, float64(1), hits)
 	require.Equal(t, float64(1), misses)
 }
+
+func TestExporter_ReconcileMetrics(t *testing.T) {
+	exporter := NewExporter(Config{Enabled: true, Port: 0, Path: "/metrics"})
+
+	exporter.SetReconcileMode("watch")
+	exporter.RecordWatchEvent("pv")
+	exporter.IncReconcileTrigger("debounce")
+	exporter.SetTruenasSnapshotAge(12.5)
+
+	families, err := exporter.registry.Gather()
+	require.NoError(t, err)
+
+	var watchCount, triggerCount float64
+	var watchMode, pollMode, snapshotAge float64
+	for _, family := range families {
+		switch family.GetName() {
+		case "truenas_monitor_watch_events_total":
+			watchCount = family.GetMetric()[0].GetCounter().GetValue()
+		case "truenas_monitor_reconcile_triggers_total":
+			triggerCount = family.GetMetric()[0].GetCounter().GetValue()
+		case "truenas_monitor_reconcile_mode":
+			for _, metric := range family.GetMetric() {
+				for _, label := range metric.GetLabel() {
+					if label.GetName() == "mode" && label.GetValue() == "watch" {
+						watchMode = metric.GetGauge().GetValue()
+					}
+					if label.GetName() == "mode" && label.GetValue() == "poll" {
+						pollMode = metric.GetGauge().GetValue()
+					}
+				}
+			}
+		case "truenas_monitor_truenas_snapshot_age_seconds":
+			snapshotAge = family.GetMetric()[0].GetGauge().GetValue()
+		}
+	}
+
+	require.Equal(t, float64(1), watchCount)
+	require.Equal(t, float64(1), triggerCount)
+	require.Equal(t, float64(1), watchMode)
+	require.Equal(t, float64(0), pollMode)
+	require.InDelta(t, 12.5, snapshotAge, 0.001)
+}

--- a/go/pkg/monitor/service.go
+++ b/go/pkg/monitor/service.go
@@ -8,10 +8,13 @@ import (
 
 	"go.uber.org/zap"
 
+	appconfig "github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/config"
+	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/inventorycache"
 	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/k8s"
 	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/logging"
 	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/metrics"
 	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/orphan"
+	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/reconcile"
 	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/truenas"
 )
 
@@ -21,9 +24,17 @@ type Service struct {
 	truenasClient   truenas.Client
 	metricsExporter *metrics.Exporter
 	logger          *logging.Logger
-	scanInterval    time.Duration
-	orphanDetector  *orphan.Detector
-	
+	scanInterval        time.Duration
+	reconcileMode       string
+	debounce            time.Duration
+	truenasPollInterval time.Duration
+	k8sConfig           k8s.Config
+	namespace           string
+	inventoryCache      *inventorycache.Cache
+	truenasPollClient   truenas.Client
+	truenasPoller       *reconcile.TruenasPoller
+	orphanDetector      *orphan.Detector
+
 	// Internal state
 	mu             sync.RWMutex
 	running        bool
@@ -38,9 +49,17 @@ type Config struct {
 	TruenasClient     truenas.Client
 	MetricsExporter   *metrics.Exporter
 	Logger            *logging.Logger
-	ScanInterval      time.Duration
-	OrphanThreshold   time.Duration
-	SnapshotRetention time.Duration
+	ScanInterval        time.Duration
+	ReconcileMode       string
+	Debounce            time.Duration
+	TruenasPollInterval time.Duration
+	K8sConfig           k8s.Config
+	Namespace           string
+	InventoryCache      *inventorycache.Cache
+	TruenasPollClient   truenas.Client
+	TruenasPoller       *reconcile.TruenasPoller
+	OrphanThreshold     time.Duration
+	SnapshotRetention   time.Duration
 }
 
 // OrphanedResource represents an orphaned resource
@@ -91,14 +110,27 @@ func NewService(config Config) (*Service, error) {
 		return nil, fmt.Errorf("failed to create orphan detector: %w", err)
 	}
 
+	reconcileMode := config.ReconcileMode
+	if reconcileMode == "" {
+		reconcileMode = appconfig.ReconcileModePoll
+	}
+
 	return &Service{
-		k8sClient:       config.K8sClient,
-		truenasClient:   config.TruenasClient,
-		metricsExporter: config.MetricsExporter,
-		logger:          config.Logger,
-		scanInterval:    config.ScanInterval,
-		orphanDetector:  orphanDetector,
-		stopChan:        make(chan struct{}),
+		k8sClient:           config.K8sClient,
+		truenasClient:       config.TruenasClient,
+		metricsExporter:     config.MetricsExporter,
+		logger:              config.Logger,
+		scanInterval:        config.ScanInterval,
+		reconcileMode:       reconcileMode,
+		debounce:            config.Debounce,
+		truenasPollInterval: config.TruenasPollInterval,
+		k8sConfig:           config.K8sConfig,
+		namespace:           config.Namespace,
+		inventoryCache:      config.InventoryCache,
+		truenasPollClient:   config.TruenasPollClient,
+		truenasPoller:       config.TruenasPoller,
+		orphanDetector:      orphanDetector,
+		stopChan:            make(chan struct{}),
 	}, nil
 }
 
@@ -121,9 +153,16 @@ func (s *Service) Start(ctx context.Context) error {
 
 	s.running = true
 
-	// Start monitoring goroutine
+	if s.metricsExporter != nil {
+		s.metricsExporter.SetReconcileMode(s.reconcileMode)
+	}
+
 	s.wg.Add(1)
-	go s.monitorLoop(ctx)
+	if s.reconcileMode == appconfig.ReconcileModeWatch {
+		go s.watchLoop(ctx)
+	} else {
+		go s.monitorLoop(ctx)
+	}
 
 	return nil
 }
@@ -176,6 +215,46 @@ func (s *Service) DetectorThresholds() (time.Duration, time.Duration) {
 		return 0, 0
 	}
 	return s.orphanDetector.Thresholds()
+}
+
+// PerformScan runs orphan detection and updates metrics (debounced watch reconcile).
+func (s *Service) PerformScan(ctx context.Context) {
+	s.performScan(ctx)
+}
+
+// PerformFullScan invalidates all inventory cache entries before scanning.
+func (s *Service) PerformFullScan(ctx context.Context) {
+	if s.inventoryCache != nil {
+		s.inventoryCache.InvalidateAll()
+	}
+	s.performScan(ctx)
+}
+
+func (s *Service) watchLoop(ctx context.Context) {
+	defer s.wg.Done()
+
+	pollClient := s.truenasPollClient
+	if pollClient == nil {
+		pollClient = s.truenasClient
+	}
+
+	controller := reconcile.NewController(reconcile.ControllerConfig{
+		K8sConfig:           s.k8sConfig,
+		Namespace:           s.namespace,
+		Debounce:            s.debounce,
+		TruenasPollInterval: s.truenasPollInterval,
+		Scan:                s.PerformScan,
+		FullScan:            s.PerformFullScan,
+		InventoryCache:      s.inventoryCache,
+		Metrics:             s.metricsExporter,
+		Logger:              s.logger,
+		TruenasPollClient: pollClient,
+		TruenasPoller:     s.truenasPoller,
+	})
+
+	if err := controller.Run(ctx); err != nil && ctx.Err() == nil {
+		s.logger.WithError(err).Error("watch reconcile stopped with error")
+	}
 }
 
 // monitorLoop runs the main monitoring loop

--- a/go/pkg/reconcile/controller.go
+++ b/go/pkg/reconcile/controller.go
@@ -1,0 +1,164 @@
+package reconcile
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/config"
+	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/inventorycache"
+	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/k8s"
+	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/logging"
+	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/metrics"
+	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/truenas"
+	"go.uber.org/zap"
+)
+
+// ScanFunc runs a full orphan detection reconcile.
+type ScanFunc func(ctx context.Context)
+
+// Controller runs watch-mode reconciliation with debouncing and TN polling.
+type Controller struct {
+	k8sConfig           k8s.Config
+	namespace           string
+	debounce            time.Duration
+	truenasPollInterval time.Duration
+	scan                ScanFunc
+	fullScan            ScanFunc
+	inventoryCache      *inventorycache.Cache
+	metrics             *metrics.Exporter
+	logger              *logging.Logger
+	truenasPollClient truenas.Client
+	truenasPoller     *TruenasPoller
+}
+
+// ControllerConfig configures watch-mode reconciliation.
+type ControllerConfig struct {
+	K8sConfig           k8s.Config
+	Namespace           string
+	Debounce            time.Duration
+	TruenasPollInterval time.Duration
+	Scan                ScanFunc
+	FullScan            ScanFunc
+	InventoryCache      *inventorycache.Cache
+	Metrics             *metrics.Exporter
+	Logger              *logging.Logger
+	TruenasPollClient truenas.Client
+	TruenasPoller     *TruenasPoller
+}
+
+// NewController creates a watch reconcile controller.
+func NewController(cfg ControllerConfig) *Controller {
+	fullScan := cfg.FullScan
+	if fullScan == nil {
+		fullScan = cfg.Scan
+	}
+	return &Controller{
+		k8sConfig:           cfg.K8sConfig,
+		namespace:           cfg.Namespace,
+		debounce:            cfg.Debounce,
+		truenasPollInterval: cfg.TruenasPollInterval,
+		scan:                cfg.Scan,
+		fullScan:            fullScan,
+		inventoryCache:      cfg.InventoryCache,
+		metrics:             cfg.Metrics,
+		logger:              cfg.Logger,
+		truenasPollClient: cfg.TruenasPollClient,
+		truenasPoller:     cfg.TruenasPoller,
+	}
+}
+
+// Run executes watch-mode reconciliation until ctx is cancelled.
+func (c *Controller) Run(ctx context.Context) error {
+	if c.metrics != nil {
+		c.metrics.SetReconcileMode(config.ReconcileModeWatch)
+	}
+
+	clientset, snapshotClient, err := k8s.NewKubernetesClients(c.k8sConfig)
+	if err != nil {
+		return err
+	}
+
+	tnPoller := c.truenasPoller
+	if tnPoller == nil {
+		tnPoller = NewTruenasPoller(c.truenasPollClient, c.truenasPollInterval)
+	}
+	pollCtx, pollCancel := context.WithCancel(ctx)
+	defer pollCancel()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		tnPoller.Run(pollCtx)
+	}()
+
+	debouncer := NewDebouncer(c.debounce, func() {
+		c.onDebouncedReconcile(ctx, tnPoller)
+	})
+
+	runWatch := func() error {
+		watchRunner := NewWatchRunner(WatchConfig{
+			Clientset:      clientset,
+			SnapshotClient: snapshotClient,
+			Namespace:      c.namespace,
+			Debouncer:      debouncer,
+			Metrics:        c.metrics,
+			OnWatchError: func(err error) {
+				c.logger.WithComponent("watch-reconcile").Warn("watch failure; running full scan",
+					zap.Error(err))
+				c.runFullScan(ctx, "full_scan")
+				debouncer.Trigger()
+			},
+		})
+		return watchRunner.Run(ctx)
+	}
+
+	c.logger.WithComponent("watch-reconcile").Info("starting watch reconcile",
+		zap.Duration("debounce", c.debounce),
+		zap.Duration("truenas_poll_interval", c.truenasPollInterval),
+	)
+
+	c.runFullScan(ctx, "full_scan")
+
+	for ctx.Err() == nil {
+		err := runWatch()
+		if ctx.Err() != nil {
+			break
+		}
+		if err == nil {
+			continue
+		}
+		c.logger.WithComponent("watch-reconcile").Warn(
+			"watch runner stopped; running full scan before restart",
+			zap.Error(err),
+		)
+		c.runFullScan(ctx, "full_scan")
+	}
+
+	debouncer.Cancel()
+	pollCancel()
+	wg.Wait()
+	return ctx.Err()
+}
+
+func (c *Controller) onDebouncedReconcile(ctx context.Context, poller *TruenasPoller) {
+	if c.inventoryCache != nil {
+		c.inventoryCache.InvalidateK8sInventory()
+	}
+	if c.metrics != nil {
+		c.metrics.IncReconcileTrigger("debounce")
+		age := poller.SnapshotAge(time.Now())
+		if age > 0 {
+			c.metrics.SetTruenasSnapshotAge(age.Seconds())
+		}
+	}
+	c.scan(ctx)
+}
+
+func (c *Controller) runFullScan(ctx context.Context, trigger string) {
+	if c.metrics != nil {
+		c.metrics.IncReconcileTrigger(trigger)
+	}
+	c.fullScan(ctx)
+}

--- a/go/pkg/reconcile/controller.go
+++ b/go/pkg/reconcile/controller.go
@@ -83,6 +83,9 @@ func (c *Controller) Run(ctx context.Context) error {
 	if tnPoller == nil {
 		tnPoller = NewTruenasPoller(c.truenasPollClient, c.truenasPollInterval)
 	}
+	if c.logger != nil {
+		tnPoller.SetLogger(c.logger)
+	}
 	pollCtx, pollCancel := context.WithCancel(ctx)
 	defer pollCancel()
 
@@ -134,6 +137,11 @@ func (c *Controller) Run(ctx context.Context) error {
 			zap.Error(err),
 		)
 		c.runFullScan(ctx, "full_scan")
+
+		select {
+		case <-ctx.Done():
+		case <-time.After(5 * time.Second):
+		}
 	}
 
 	debouncer.Cancel()

--- a/go/pkg/reconcile/debounce.go
+++ b/go/pkg/reconcile/debounce.go
@@ -41,9 +41,10 @@ func (d *Debouncer) Trigger() {
 		}
 	}
 
-	d.timer = time.AfterFunc(d.delay, func() {
+	var self *time.Timer
+	self = time.AfterFunc(d.delay, func() {
 		d.mu.Lock()
-		if d.stopped {
+		if d.stopped || d.timer != self {
 			d.mu.Unlock()
 			return
 		}
@@ -52,6 +53,7 @@ func (d *Debouncer) Trigger() {
 			d.onFire()
 		}
 	})
+	d.timer = self
 }
 
 // Cancel stops pending debounced callbacks.

--- a/go/pkg/reconcile/debounce.go
+++ b/go/pkg/reconcile/debounce.go
@@ -1,0 +1,72 @@
+package reconcile
+
+import (
+	"sync"
+	"time"
+)
+
+// Debouncer coalesces rapid triggers into a single callback after a quiet period.
+type Debouncer struct {
+	delay  time.Duration
+	onFire func()
+
+	mu      sync.Mutex
+	timer   *time.Timer
+	stopped bool
+}
+
+// NewDebouncer creates a debouncer that calls onFire after delay without further triggers.
+func NewDebouncer(delay time.Duration, onFire func()) *Debouncer {
+	return &Debouncer{
+		delay:  delay,
+		onFire: onFire,
+	}
+}
+
+// Trigger schedules or resets the debounced callback.
+func (d *Debouncer) Trigger() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.stopped {
+		return
+	}
+
+	if d.timer != nil {
+		if !d.timer.Stop() {
+			select {
+			case <-d.timer.C:
+			default:
+			}
+		}
+	}
+
+	d.timer = time.AfterFunc(d.delay, func() {
+		d.mu.Lock()
+		if d.stopped {
+			d.mu.Unlock()
+			return
+		}
+		d.mu.Unlock()
+		if d.onFire != nil {
+			d.onFire()
+		}
+	})
+}
+
+// Cancel stops pending debounced callbacks.
+func (d *Debouncer) Cancel() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.stopped = true
+	if d.timer != nil {
+		if !d.timer.Stop() {
+			select {
+			case <-d.timer.C:
+			default:
+			}
+		}
+		d.timer = nil
+	}
+}

--- a/go/pkg/reconcile/debounce_test.go
+++ b/go/pkg/reconcile/debounce_test.go
@@ -1,0 +1,63 @@
+package reconcile
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDebouncerFiresOnceAfterQuietPeriod(t *testing.T) {
+	var count atomic.Int32
+	done := make(chan struct{}, 1)
+
+	d := NewDebouncer(50*time.Millisecond, func() {
+		count.Add(1)
+		done <- struct{}{}
+	})
+
+	d.Trigger()
+	d.Trigger()
+	d.Trigger()
+
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("debouncer did not fire")
+	}
+
+	assert.Equal(t, int32(1), count.Load())
+}
+
+func TestDebouncerCancelPreventsFire(t *testing.T) {
+	var count atomic.Int32
+
+	d := NewDebouncer(30*time.Millisecond, func() {
+		count.Add(1)
+	})
+
+	d.Trigger()
+	d.Cancel()
+	time.Sleep(100 * time.Millisecond)
+
+	assert.Equal(t, int32(0), count.Load())
+}
+
+func TestDebouncerResetExtendsQuietPeriod(t *testing.T) {
+	var count atomic.Int32
+
+	d := NewDebouncer(40*time.Millisecond, func() {
+		count.Add(1)
+	})
+
+	d.Trigger()
+	time.Sleep(25 * time.Millisecond)
+	d.Trigger()
+	time.Sleep(25 * time.Millisecond)
+
+	assert.Equal(t, int32(0), count.Load())
+
+	time.Sleep(30 * time.Millisecond)
+	assert.Equal(t, int32(1), count.Load())
+}

--- a/go/pkg/reconcile/truenas_poller_test.go
+++ b/go/pkg/reconcile/truenas_poller_test.go
@@ -1,0 +1,69 @@
+package reconcile
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/truenas"
+)
+
+type fakeTruenasClient struct {
+	volumeCalls   atomic.Int32
+	snapshotCalls atomic.Int32
+	volumes       []truenas.Volume
+	snapshots     []truenas.Snapshot
+}
+
+func (f *fakeTruenasClient) ListVolumes(context.Context) ([]truenas.Volume, error) {
+	f.volumeCalls.Add(1)
+	return append([]truenas.Volume(nil), f.volumes...), nil
+}
+
+func (f *fakeTruenasClient) ListSnapshots(context.Context) ([]truenas.Snapshot, error) {
+	f.snapshotCalls.Add(1)
+	return append([]truenas.Snapshot(nil), f.snapshots...), nil
+}
+
+func (f *fakeTruenasClient) ListPools(context.Context) ([]truenas.Pool, error) {
+	return nil, nil
+}
+
+func (f *fakeTruenasClient) GetSystemInfo(context.Context) (*truenas.SystemInfo, error) {
+	return &truenas.SystemInfo{}, nil
+}
+
+func (f *fakeTruenasClient) TestConnection(context.Context) error {
+	return nil
+}
+
+func TestTruenasPollerUpdatesSnapshot(t *testing.T) {
+	inner := &fakeTruenasClient{
+		volumes:   []truenas.Volume{{Name: "vol-a"}},
+		snapshots: []truenas.Snapshot{{Name: "snap-a"}},
+	}
+	poller := NewTruenasPoller(inner, time.Hour)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go poller.Run(ctx)
+
+	require.Eventually(t, func() bool {
+		snap := poller.Snapshot()
+		return !snap.UpdatedAt.IsZero() && len(snap.Volumes) == 1
+	}, time.Second, 10*time.Millisecond)
+
+	assert.Equal(t, int32(1), inner.volumeCalls.Load())
+	assert.Equal(t, int32(1), inner.snapshotCalls.Load())
+
+	wrapped := WrapTruenasWithSnapshot(inner, poller)
+	vols, err := wrapped.ListVolumes(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "vol-a", vols[0].Name)
+	assert.Equal(t, int32(1), inner.volumeCalls.Load())
+}

--- a/go/pkg/reconcile/truenas_snapshot.go
+++ b/go/pkg/reconcile/truenas_snapshot.go
@@ -1,0 +1,131 @@
+package reconcile
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/truenas"
+)
+
+// TruenasSnapshot holds the latest TrueNAS inventory from background polling.
+type TruenasSnapshot struct {
+	Volumes   []truenas.Volume
+	Snapshots []truenas.Snapshot
+	UpdatedAt time.Time
+}
+
+// TruenasPoller periodically refreshes TrueNAS inventory into a thread-safe snapshot.
+type TruenasPoller struct {
+	client   truenas.Client
+	interval time.Duration
+	now      func() time.Time
+
+	mu   sync.RWMutex
+	snap TruenasSnapshot
+}
+
+// NewTruenasPoller creates a poller for the given client and interval.
+func NewTruenasPoller(client truenas.Client, interval time.Duration) *TruenasPoller {
+	return &TruenasPoller{
+		client:   client,
+		interval: interval,
+		now:      time.Now,
+	}
+}
+
+// Run polls TrueNAS until ctx is cancelled.
+func (p *TruenasPoller) Run(ctx context.Context) {
+	p.pollOnce(ctx)
+
+	ticker := time.NewTicker(p.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			p.pollOnce(ctx)
+		}
+	}
+}
+
+func (p *TruenasPoller) pollOnce(ctx context.Context) {
+	volumes, err := p.client.ListVolumes(ctx)
+	if err != nil {
+		return
+	}
+	snapshots, err := p.client.ListSnapshots(ctx)
+	if err != nil {
+		return
+	}
+
+	p.mu.Lock()
+	p.snap = TruenasSnapshot{
+		Volumes:   append([]truenas.Volume(nil), volumes...),
+		Snapshots: append([]truenas.Snapshot(nil), snapshots...),
+		UpdatedAt: p.now(),
+	}
+	p.mu.Unlock()
+}
+
+// Snapshot returns a copy of the latest polled inventory.
+func (p *TruenasPoller) Snapshot() TruenasSnapshot {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return TruenasSnapshot{
+		Volumes:   append([]truenas.Volume(nil), p.snap.Volumes...),
+		Snapshots: append([]truenas.Snapshot(nil), p.snap.Snapshots...),
+		UpdatedAt: p.snap.UpdatedAt,
+	}
+}
+
+// SnapshotAge returns time since the last successful poll, or zero if never polled.
+func (p *TruenasPoller) SnapshotAge(now time.Time) time.Duration {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if p.snap.UpdatedAt.IsZero() {
+		return 0
+	}
+	return now.Sub(p.snap.UpdatedAt)
+}
+
+// SnapshotTruenasClient serves ListVolumes/ListSnapshots from a poller snapshot.
+type SnapshotTruenasClient struct {
+	inner  truenas.Client
+	source *TruenasPoller
+}
+
+// WrapTruenasWithSnapshot returns a client that reads TN lists from the poller snapshot.
+func WrapTruenasWithSnapshot(inner truenas.Client, source *TruenasPoller) truenas.Client {
+	return &SnapshotTruenasClient{inner: inner, source: source}
+}
+
+func (c *SnapshotTruenasClient) ListVolumes(ctx context.Context) ([]truenas.Volume, error) {
+	snap := c.source.Snapshot()
+	if !snap.UpdatedAt.IsZero() {
+		return append([]truenas.Volume(nil), snap.Volumes...), nil
+	}
+	return c.inner.ListVolumes(ctx)
+}
+
+func (c *SnapshotTruenasClient) ListSnapshots(ctx context.Context) ([]truenas.Snapshot, error) {
+	snap := c.source.Snapshot()
+	if !snap.UpdatedAt.IsZero() {
+		return append([]truenas.Snapshot(nil), snap.Snapshots...), nil
+	}
+	return c.inner.ListSnapshots(ctx)
+}
+
+func (c *SnapshotTruenasClient) ListPools(ctx context.Context) ([]truenas.Pool, error) {
+	return c.inner.ListPools(ctx)
+}
+
+func (c *SnapshotTruenasClient) GetSystemInfo(ctx context.Context) (*truenas.SystemInfo, error) {
+	return c.inner.GetSystemInfo(ctx)
+}
+
+func (c *SnapshotTruenasClient) TestConnection(ctx context.Context) error {
+	return c.inner.TestConnection(ctx)
+}

--- a/go/pkg/reconcile/truenas_snapshot.go
+++ b/go/pkg/reconcile/truenas_snapshot.go
@@ -5,7 +5,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/logging"
 	"github.com/tomazb/kubernetes-truenas-democratic-tool/pkg/truenas"
+	"go.uber.org/zap"
 )
 
 // TruenasSnapshot holds the latest TrueNAS inventory from background polling.
@@ -20,6 +22,7 @@ type TruenasPoller struct {
 	client   truenas.Client
 	interval time.Duration
 	now      func() time.Time
+	logger   *logging.Logger
 
 	mu   sync.RWMutex
 	snap TruenasSnapshot
@@ -32,6 +35,11 @@ func NewTruenasPoller(client truenas.Client, interval time.Duration) *TruenasPol
 		interval: interval,
 		now:      time.Now,
 	}
+}
+
+// SetLogger attaches a logger for background poll failures.
+func (p *TruenasPoller) SetLogger(logger *logging.Logger) {
+	p.logger = logger
 }
 
 // Run polls TrueNAS until ctx is cancelled.
@@ -54,10 +62,12 @@ func (p *TruenasPoller) Run(ctx context.Context) {
 func (p *TruenasPoller) pollOnce(ctx context.Context) {
 	volumes, err := p.client.ListVolumes(ctx)
 	if err != nil {
+		p.logPollError("list volumes", err)
 		return
 	}
 	snapshots, err := p.client.ListSnapshots(ctx)
 	if err != nil {
+		p.logPollError("list snapshots", err)
 		return
 	}
 
@@ -128,4 +138,15 @@ func (c *SnapshotTruenasClient) GetSystemInfo(ctx context.Context) (*truenas.Sys
 
 func (c *SnapshotTruenasClient) TestConnection(ctx context.Context) error {
 	return c.inner.TestConnection(ctx)
+}
+
+func (p *TruenasPoller) logPollError(operation string, err error) {
+	if p.logger == nil {
+		return
+	}
+	p.logger.WithComponent("truenas-poller").Warn(
+		"TrueNAS background poll failed",
+		zap.String("operation", operation),
+		zap.Error(err),
+	)
 }

--- a/go/pkg/reconcile/watch.go
+++ b/go/pkg/reconcile/watch.go
@@ -1,0 +1,178 @@
+package reconcile
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+
+	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
+	snapshotclient "github.com/kubernetes-csi/external-snapshotter/client/v6/clientset/versioned"
+	snapshotinformers "github.com/kubernetes-csi/external-snapshotter/client/v6/informers/externalversions"
+)
+
+// WatchMetrics records watch-driven reconcile signals.
+type WatchMetrics interface {
+	RecordWatchEvent(resource string)
+}
+
+// WatchRunner wires Kubernetes informers to a debouncer.
+type WatchRunner struct {
+	clientset      kubernetes.Interface
+	snapshotClient snapshotclient.Interface
+	namespace      string
+	debouncer      *Debouncer
+	metrics        WatchMetrics
+	onWatchError   func(error)
+
+	stopCh   chan struct{}
+	stopOnce sync.Once
+}
+
+// WatchConfig holds informer watch settings.
+type WatchConfig struct {
+	Clientset      kubernetes.Interface
+	SnapshotClient snapshotclient.Interface
+	Namespace      string
+	Debouncer      *Debouncer
+	Metrics        WatchMetrics
+	OnWatchError   func(error)
+}
+
+// NewWatchRunner creates a watch runner for PV/PVC/VolumeSnapshot resources.
+func NewWatchRunner(cfg WatchConfig) *WatchRunner {
+	return &WatchRunner{
+		clientset:      cfg.Clientset,
+		snapshotClient: cfg.SnapshotClient,
+		namespace:      cfg.Namespace,
+		debouncer:      cfg.Debouncer,
+		metrics:        cfg.Metrics,
+		onWatchError:   cfg.OnWatchError,
+		stopCh:         make(chan struct{}),
+	}
+}
+
+// Run starts informers until ctx is done or Stop is called.
+func (w *WatchRunner) Run(ctx context.Context) error {
+	if w.clientset == nil || w.snapshotClient == nil {
+		return fmt.Errorf("kubernetes clients are required for watch mode")
+	}
+
+	factory := informers.NewSharedInformerFactory(w.clientset, 0)
+	pvInformer := factory.Core().V1().PersistentVolumes().Informer()
+	pvcInformer := factory.Core().V1().PersistentVolumeClaims().Informer()
+
+	snapshotFactory := snapshotinformers.NewSharedInformerFactory(w.snapshotClient, 0)
+	vsInformer := snapshotFactory.Snapshot().V1().VolumeSnapshots().Informer()
+
+	pvHandler := cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(_ any) { w.trigger("pv") },
+		UpdateFunc: func(_, _ any) { w.trigger("pv") },
+		DeleteFunc: func(_ any) { w.trigger("pv") },
+	}
+	pvcHandler := cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj any) { w.onPVCEvent(obj) },
+		UpdateFunc: func(_, obj any) { w.onPVCEvent(obj) },
+		DeleteFunc: func(obj any) { w.onPVCEvent(obj) },
+	}
+	vsHandler := cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj any) { w.onSnapshotEvent(obj) },
+		UpdateFunc: func(_, obj any) { w.onSnapshotEvent(obj) },
+		DeleteFunc: func(obj any) { w.onSnapshotEvent(obj) },
+	}
+
+	_, err := pvInformer.AddEventHandler(pvHandler)
+	if err != nil {
+		return err
+	}
+	_, err = pvcInformer.AddEventHandler(pvcHandler)
+	if err != nil {
+		return err
+	}
+	_, err = vsInformer.AddEventHandler(vsHandler)
+	if err != nil {
+		return err
+	}
+
+	factory.Start(w.stopCh)
+	snapshotFactory.Start(w.stopCh)
+
+	if !cache.WaitForCacheSync(ctx.Done(), pvInformer.HasSynced, pvcInformer.HasSynced, vsInformer.HasSynced) {
+		err := ctx.Err()
+		if err == nil {
+			err = fmt.Errorf("failed to sync informer caches")
+		}
+		if w.onWatchError != nil {
+			w.onWatchError(err)
+		}
+		return err
+	}
+
+	<-ctx.Done()
+	w.Stop()
+	return ctx.Err()
+}
+
+// Stop shuts down informers.
+func (w *WatchRunner) Stop() {
+	w.stopOnce.Do(func() {
+		close(w.stopCh)
+	})
+}
+
+func (w *WatchRunner) trigger(resource string) {
+	if w.metrics != nil {
+		w.metrics.RecordWatchEvent(resource)
+	}
+	if w.debouncer != nil {
+		w.debouncer.Trigger()
+	}
+}
+
+func (w *WatchRunner) onPVCEvent(obj any) {
+	pvc, ok := toPVC(obj)
+	if !ok {
+		return
+	}
+	if w.namespace != "" && pvc.Namespace != w.namespace {
+		return
+	}
+	w.trigger("pvc")
+}
+
+func (w *WatchRunner) onSnapshotEvent(obj any) {
+	vs, ok := toVolumeSnapshot(obj)
+	if !ok {
+		return
+	}
+	if w.namespace != "" && vs.Namespace != w.namespace {
+		return
+	}
+	w.trigger("snapshot")
+}
+
+func toPVC(obj any) (*corev1.PersistentVolumeClaim, bool) {
+	switch t := obj.(type) {
+	case *corev1.PersistentVolumeClaim:
+		return t, true
+	case cache.DeletedFinalStateUnknown:
+		return toPVC(t.Obj)
+	default:
+		return nil, false
+	}
+}
+
+func toVolumeSnapshot(obj any) (*snapshotv1.VolumeSnapshot, bool) {
+	switch t := obj.(type) {
+	case *snapshotv1.VolumeSnapshot:
+		return t, true
+	case cache.DeletedFinalStateUnknown:
+		return toVolumeSnapshot(t.Obj)
+	default:
+		return nil, false
+	}
+}

--- a/go/pkg/reconcile/watch.go
+++ b/go/pkg/reconcile/watch.go
@@ -62,12 +62,37 @@ func (w *WatchRunner) Run(ctx context.Context) error {
 		return fmt.Errorf("kubernetes clients are required for watch mode")
 	}
 
-	factory := informers.NewSharedInformerFactory(w.clientset, 0)
-	pvInformer := factory.Core().V1().PersistentVolumes().Informer()
-	pvcInformer := factory.Core().V1().PersistentVolumeClaims().Informer()
+	defer w.Stop()
 
-	snapshotFactory := snapshotinformers.NewSharedInformerFactory(w.snapshotClient, 0)
-	vsInformer := snapshotFactory.Snapshot().V1().VolumeSnapshots().Informer()
+	clusterFactory := informers.NewSharedInformerFactory(w.clientset, 0)
+	pvInformer := clusterFactory.Core().V1().PersistentVolumes().Informer()
+
+	var (
+		pvcInformer      cache.SharedIndexInformer
+		vsInformer       cache.SharedIndexInformer
+		namespaceFactory informers.SharedInformerFactory
+		snapshotFactory  snapshotinformers.SharedInformerFactory
+	)
+
+	if w.namespace != "" {
+		namespaceFactory = informers.NewSharedInformerFactoryWithOptions(
+			w.clientset,
+			0,
+			informers.WithNamespace(w.namespace),
+		)
+		pvcInformer = namespaceFactory.Core().V1().PersistentVolumeClaims().Informer()
+
+		snapshotFactory = snapshotinformers.NewSharedInformerFactoryWithOptions(
+			w.snapshotClient,
+			0,
+			snapshotinformers.WithNamespace(w.namespace),
+		)
+		vsInformer = snapshotFactory.Snapshot().V1().VolumeSnapshots().Informer()
+	} else {
+		pvcInformer = clusterFactory.Core().V1().PersistentVolumeClaims().Informer()
+		snapshotFactory = snapshotinformers.NewSharedInformerFactory(w.snapshotClient, 0)
+		vsInformer = snapshotFactory.Snapshot().V1().VolumeSnapshots().Informer()
+	}
 
 	pvHandler := cache.ResourceEventHandlerFuncs{
 		AddFunc:    func(_ any) { w.trigger("pv") },
@@ -85,20 +110,20 @@ func (w *WatchRunner) Run(ctx context.Context) error {
 		DeleteFunc: func(obj any) { w.onSnapshotEvent(obj) },
 	}
 
-	_, err := pvInformer.AddEventHandler(pvHandler)
-	if err != nil {
+	if _, err := pvInformer.AddEventHandler(pvHandler); err != nil {
 		return err
 	}
-	_, err = pvcInformer.AddEventHandler(pvcHandler)
-	if err != nil {
+	if _, err := pvcInformer.AddEventHandler(pvcHandler); err != nil {
 		return err
 	}
-	_, err = vsInformer.AddEventHandler(vsHandler)
-	if err != nil {
+	if _, err := vsInformer.AddEventHandler(vsHandler); err != nil {
 		return err
 	}
 
-	factory.Start(w.stopCh)
+	clusterFactory.Start(w.stopCh)
+	if namespaceFactory != nil {
+		namespaceFactory.Start(w.stopCh)
+	}
 	snapshotFactory.Start(w.stopCh)
 
 	if !cache.WaitForCacheSync(ctx.Done(), pvInformer.HasSynced, pvcInformer.HasSynced, vsInformer.HasSynced) {
@@ -113,7 +138,6 @@ func (w *WatchRunner) Run(ctx context.Context) error {
 	}
 
 	<-ctx.Done()
-	w.Stop()
 	return ctx.Err()
 }
 

--- a/python/tests/unit/test_cli_watch.py
+++ b/python/tests/unit/test_cli_watch.py
@@ -1,0 +1,41 @@
+"""CLI tests for watch command."""
+
+from datetime import timedelta
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from truenas_storage_monitor.cli import cli
+
+
+@patch("truenas_storage_monitor.cli.load_config")
+def test_watch_rejects_poll_mode_without_override(mock_load_config):
+    runner = CliRunner()
+    config = MagicMock()
+    config.reconcile_mode = "poll"
+    mock_load_config.return_value = config
+
+    result = runner.invoke(cli, ["watch"])
+
+    assert result.exit_code == 1
+    assert "reconcile_mode=watch" in result.output
+
+
+@patch("truenas_storage_monitor.cli.Monitor")
+@patch("truenas_storage_monitor.cli.WatchReconciler")
+@patch("truenas_storage_monitor.cli.load_config")
+def test_watch_accepts_mode_override(
+    mock_load_config, mock_reconciler, _mock_monitor
+):
+    runner = CliRunner()
+    config = MagicMock()
+    config.reconcile_mode = "poll"
+    config.debounce = timedelta(seconds=30)
+    config.truenas_poll_interval = timedelta(minutes=5)
+    mock_load_config.return_value = config
+    mock_reconciler.return_value.run_until_signal.return_value = None
+
+    result = runner.invoke(cli, ["watch", "--mode", "watch"])
+
+    assert result.exit_code == 0
+    mock_reconciler.assert_called_once()

--- a/python/tests/unit/test_cli_watch.py
+++ b/python/tests/unit/test_cli_watch.py
@@ -24,9 +24,7 @@ def test_watch_rejects_poll_mode_without_override(mock_load_config):
 @patch("truenas_storage_monitor.cli.Monitor")
 @patch("truenas_storage_monitor.cli.WatchReconciler")
 @patch("truenas_storage_monitor.cli.load_config")
-def test_watch_accepts_mode_override(
-    mock_load_config, mock_reconciler, _mock_monitor
-):
+def test_watch_accepts_mode_override(mock_load_config, mock_reconciler, _mock_monitor):
     runner = CliRunner()
     config = MagicMock()
     config.reconcile_mode = "poll"

--- a/python/tests/unit/test_config.py
+++ b/python/tests/unit/test_config.py
@@ -295,6 +295,24 @@ class TestConfigClass:
         assert config.orphan_threshold == timedelta(hours=48)
         assert config.snapshot_retention == timedelta(days=7)
 
+    def test_reconcile_mode_config_properties(self):
+        """Watch-mode config properties parse and validate."""
+        from datetime import timedelta
+
+        from truenas_storage_monitor.config import Config
+
+        config = Config.__new__(Config)
+        config.data = {
+            "monitoring": {
+                "reconcile_mode": "watch",
+                "debounce": "45s",
+                "truenas_poll_interval": "10m",
+            }
+        }
+        assert config.reconcile_mode == "watch"
+        assert config.debounce == timedelta(seconds=45)
+        assert config.truenas_poll_interval == timedelta(minutes=10)
+
     def test_cache_config_properties(self):
         """Cache config properties coerce and validate values."""
         from datetime import timedelta

--- a/python/tests/unit/test_reconcile.py
+++ b/python/tests/unit/test_reconcile.py
@@ -57,7 +57,7 @@ def test_watch_reconciler_debounced_scan():
         "scan_duration": 0.1,
     }
     monitor.k8s_client = MagicMock()
-    monitor.k8s_client._inventory_cache = None
+    monitor.k8s_client._cache = None
     monitor.truenas_client = MagicMock()
     monitor.truenas_client.get_volumes.return_value = []
     monitor.truenas_client.get_snapshots.return_value = []

--- a/python/tests/unit/test_reconcile.py
+++ b/python/tests/unit/test_reconcile.py
@@ -1,0 +1,85 @@
+"""Tests for watch-mode reconcile helpers."""
+
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from truenas_storage_monitor.reconcile import Debouncer, WatchReconciler
+
+
+def test_debouncer_coalesces_events():
+    calls = []
+
+    debouncer = Debouncer(0.05, lambda: calls.append(time.time()))
+    debouncer.trigger()
+    debouncer.trigger()
+    debouncer.trigger()
+    time.sleep(0.15)
+    assert len(calls) == 1
+
+
+def test_debouncer_cancel_prevents_fire():
+    calls = []
+
+    debouncer = Debouncer(0.05, lambda: calls.append(1))
+    debouncer.trigger()
+    debouncer.cancel()
+    time.sleep(0.1)
+    assert calls == []
+
+
+def test_watch_reconciler_debounced_scan():
+    from truenas_storage_monitor.config import Config
+
+    config = Config.__new__(Config)
+    config.data = {
+        "monitoring": {
+            "reconcile_mode": "watch",
+            "debounce": "1s",
+            "truenas_poll_interval": "1h",
+            "orphan_threshold": "24h",
+            "snapshot": {"max_age": "30d"},
+        },
+        "openshift": {"namespace": "default"},
+        "truenas": {
+            "url": "https://tn.example.com",
+            "username": "u",
+            "password": "p",
+        },
+        "performance": {"cache": {"enabled": False}},
+    }
+
+    monitor = MagicMock()
+    monitor.find_orphaned_resources.return_value = {
+        "summary": {"orphaned_pvs": 0, "orphaned_pvcs": 0, "orphaned_snapshots": 0},
+        "scan_duration": 0.1,
+    }
+    monitor.k8s_client = MagicMock()
+    monitor.k8s_client._inventory_cache = None
+    monitor.truenas_client = MagicMock()
+    monitor.truenas_client.get_volumes.return_value = []
+    monitor.truenas_client.get_snapshots.return_value = []
+
+    reconciler = WatchReconciler(monitor, config)
+
+    with patch.object(reconciler, "_start_k8s_watches"):
+        stop_timer = threading.Timer(0.2, reconciler._stop.set)
+        stop_timer.start()
+        try:
+            reconciler.run_until_signal()
+        finally:
+            stop_timer.cancel()
+
+    assert monitor.find_orphaned_resources.call_count >= 1
+
+
+def test_config_reconcile_mode_validation():
+    from truenas_storage_monitor.config import Config
+    from truenas_storage_monitor.exceptions import ConfigurationError
+
+    config = Config.__new__(Config)
+    config.data = {"monitoring": {"reconcile_mode": "invalid"}}
+    with pytest.raises(ConfigurationError, match="reconcile_mode"):
+        _ = config.reconcile_mode

--- a/python/truenas_storage_monitor/cli.py
+++ b/python/truenas_storage_monitor/cli.py
@@ -8,8 +8,10 @@ from rich.console import Console
 from rich.table import Table
 
 from . import __version__
-from .config import load_config
+from .config import Config, load_config
 from .exceptions import TrueNASMonitorError
+from .monitor import Monitor
+from .reconcile import WatchReconciler
 
 console = Console()
 
@@ -152,6 +154,38 @@ def validate(ctx: click.Context) -> None:
         sys.exit(1)
     else:
         console.print("\n[green]All checks passed![/green]")
+
+
+@cli.command()
+@click.option(
+    "--mode",
+    type=click.Choice(["poll", "watch"]),
+    default=None,
+    help="Override monitoring.reconcile_mode from config",
+)
+@click.pass_context
+def watch(ctx: click.Context, mode: Optional[str]) -> None:
+    """Run long-running watch-mode orphan reconciliation until interrupted."""
+    config: Config = ctx.obj["config"]
+    reconcile_mode = (mode or config.reconcile_mode).lower()
+    if reconcile_mode != "watch":
+        console.print(
+            "[red]watch requires reconcile_mode=watch; "
+            "set monitoring.reconcile_mode or pass --mode watch[/red]"
+        )
+        sys.exit(1)
+
+    debounce = config.debounce
+    tn_poll = config.truenas_poll_interval
+    console.print(
+        "[yellow]Starting watch reconcile "
+        f"(debounce={debounce}, truenas_poll={tn_poll})...[/yellow]"
+    )
+    console.print("[cyan]Press Ctrl+C to stop[/cyan]")
+
+    reconciler = WatchReconciler(Monitor(config), config)
+    reconciler.run_until_signal()
+    console.print("[green]Watch reconcile stopped[/green]")
 
 
 @cli.command()

--- a/python/truenas_storage_monitor/config.py
+++ b/python/truenas_storage_monitor/config.py
@@ -132,6 +132,34 @@ class Config:
         return parse_duration(raw)
 
     @property
+    def reconcile_mode(self) -> str:
+        """Reconcile mode: poll (default) or watch."""
+        raw = str(self.monitoring.get("reconcile_mode", "poll")).strip().lower()
+        if raw not in {"poll", "watch"}:
+            raise ConfigurationError(
+                f"monitoring.reconcile_mode must be 'poll' or 'watch', got {raw!r}"
+            )
+        return raw
+
+    @property
+    def debounce(self) -> timedelta:
+        """Debounced reconcile quiet period for watch mode."""
+        raw = self.monitoring.get("debounce", "30s")
+        value = parse_duration(raw)
+        if value < timedelta(seconds=1):
+            raise ConfigurationError("monitoring.debounce must be at least 1 second")
+        return value
+
+    @property
+    def truenas_poll_interval(self) -> timedelta:
+        """TrueNAS background poll interval for watch mode."""
+        raw = self.monitoring.get("truenas_poll_interval", "5m")
+        value = parse_duration(raw)
+        if value < timedelta(minutes=1):
+            raise ConfigurationError("monitoring.truenas_poll_interval must be at least 1 minute")
+        return value
+
+    @property
     def metrics_enabled(self) -> bool:
         """Whether Prometheus metrics export is enabled."""
         return bool(self.get("metrics.enabled", False))

--- a/python/truenas_storage_monitor/inventory_cache.py
+++ b/python/truenas_storage_monitor/inventory_cache.py
@@ -68,6 +68,18 @@ class InventoryCache:
 
         return loaded
 
+    def invalidate_prefix(self, prefix: str) -> None:
+        """Remove cache entries whose keys start with prefix."""
+        with self._lock:
+            keys = [key for key in self._entries if key.startswith(prefix)]
+            for key in keys:
+                del self._entries[key]
+
+    def clear(self) -> None:
+        """Remove all cache entries."""
+        with self._lock:
+            self._entries.clear()
+
 
 def namespace_key(prefix: str, namespace: Optional[str]) -> str:
     """Build a cache key with optional namespace scope."""

--- a/python/truenas_storage_monitor/k8s_client.py
+++ b/python/truenas_storage_monitor/k8s_client.py
@@ -665,10 +665,15 @@ class K8sClient:
                 )
 
             for event in stream:
-                metadata = event["object"]["metadata"]
+                obj = event.get("object") or {}
+                metadata = obj.get("metadata") or {}
+                name = metadata.get("name")
+                if not name:
+                    # Skip non-resource watch events (e.g., ERROR/BOOKMARK payloads).
+                    continue
                 yield {
-                    "type": event["type"],
-                    "name": metadata["name"],
+                    "type": event.get("type", "UNKNOWN"),
+                    "name": name,
                     "namespace": metadata.get("namespace"),
                     "timestamp": utc_now(),
                 }

--- a/python/truenas_storage_monitor/k8s_client.py
+++ b/python/truenas_storage_monitor/k8s_client.py
@@ -634,3 +634,43 @@ class K8sClient:
                 }
         finally:
             w.stop()
+
+    def watch_volume_snapshots(
+        self, namespace: Optional[str] = None, timeout_seconds: Optional[int] = None
+    ) -> Generator[Dict[str, Any], None, None]:
+        """Watch VolumeSnapshot custom resources."""
+        w = watch.Watch()
+        group = "snapshot.storage.k8s.io"
+        version = "v1"
+        plural = "volumesnapshots"
+        namespace = namespace or self.config.namespace
+
+        try:
+            if namespace:
+                stream = w.stream(
+                    self.custom_objects.list_namespaced_custom_object,
+                    group=group,
+                    version=version,
+                    namespace=namespace,
+                    plural=plural,
+                    timeout_seconds=timeout_seconds,
+                )
+            else:
+                stream = w.stream(
+                    self.custom_objects.list_cluster_custom_object,
+                    group=group,
+                    version=version,
+                    plural=plural,
+                    timeout_seconds=timeout_seconds,
+                )
+
+            for event in stream:
+                metadata = event["object"]["metadata"]
+                yield {
+                    "type": event["type"],
+                    "name": metadata["name"],
+                    "namespace": metadata.get("namespace"),
+                    "timestamp": utc_now(),
+                }
+        finally:
+            w.stop()

--- a/python/truenas_storage_monitor/k8s_client.py
+++ b/python/truenas_storage_monitor/k8s_client.py
@@ -280,7 +280,7 @@ class K8sClient:
         try:
             namespace = namespace or self.config.namespace
             group = "snapshot.storage.k8s.io"
-            version = "v1beta1"
+            version = "v1"
             plural = "volumesnapshots"
 
             if namespace:

--- a/python/truenas_storage_monitor/reconcile.py
+++ b/python/truenas_storage_monitor/reconcile.py
@@ -1,0 +1,191 @@
+"""Watch-mode incremental reconcile for the Python monitor."""
+
+from __future__ import annotations
+
+import logging
+import signal
+import threading
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Callable, List, Optional
+
+from .config import Config
+from .exceptions import TrueNASMonitorError
+from .monitor import Monitor
+from .time_utils import utc_now
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TruenasSnapshot:
+    """In-memory TrueNAS inventory from background polling."""
+
+    volumes: List[Any] = field(default_factory=list)
+    snapshots: List[Any] = field(default_factory=list)
+    updated_at: Optional[datetime] = None
+
+
+class Debouncer:
+    """Coalesce rapid events into a single delayed callback."""
+
+    def __init__(self, delay_seconds: float, callback: Callable[[], None]) -> None:
+        self._delay = delay_seconds
+        self._callback = callback
+        self._timer: Optional[threading.Timer] = None
+        self._lock = threading.Lock()
+        self._stopped = False
+
+    def trigger(self) -> None:
+        with self._lock:
+            if self._stopped:
+                return
+            if self._timer is not None:
+                self._timer.cancel()
+            self._timer = threading.Timer(self._delay, self._fire)
+            self._timer.daemon = True
+            self._timer.start()
+
+    def cancel(self) -> None:
+        with self._lock:
+            self._stopped = True
+            if self._timer is not None:
+                self._timer.cancel()
+                self._timer = None
+
+    def _fire(self) -> None:
+        with self._lock:
+            if self._stopped:
+                return
+        self._callback()
+
+
+class WatchReconciler:
+    """Runs debounced orphan detection driven by Kubernetes watches."""
+
+    def __init__(self, monitor: Monitor, config: Config) -> None:
+        self._monitor = monitor
+        self._config = config
+        self._stop = threading.Event()
+        self._tn_snapshot = TruenasSnapshot()
+        self._tn_lock = threading.Lock()
+        self._watch_threads: List[threading.Thread] = []
+
+    def run_until_signal(self) -> None:
+        """Block until SIGINT/SIGTERM, running watch reconcile."""
+        debouncer = Debouncer(
+            self._config.debounce.total_seconds(),
+            self._debounced_reconcile,
+        )
+
+        self._run_full_scan("startup")
+
+        tn_thread = threading.Thread(
+            target=self._truenas_poll_loop,
+            name="truenas-poller",
+            daemon=True,
+        )
+        tn_thread.start()
+
+        self._start_k8s_watches(debouncer)
+
+        previous = signal.signal(signal.SIGINT, lambda *_: self._stop.set())
+        previous_term = signal.signal(signal.SIGTERM, lambda *_: self._stop.set())
+        try:
+            while not self._stop.wait(timeout=1):
+                pass
+        finally:
+            signal.signal(signal.SIGINT, previous)
+            signal.signal(signal.SIGTERM, previous_term)
+            debouncer.cancel()
+            self._stop.set()
+
+    def _truenas_poll_loop(self) -> None:
+        interval = self._config.truenas_poll_interval.total_seconds()
+        while not self._stop.is_set():
+            try:
+                volumes = self._monitor.truenas_client.get_volumes()
+                snapshots = self._monitor.truenas_client.get_snapshots()
+                with self._tn_lock:
+                    self._tn_snapshot = TruenasSnapshot(
+                        volumes=list(volumes),
+                        snapshots=list(snapshots),
+                        updated_at=utc_now(),
+                    )
+            except Exception as exc:  # noqa: BLE001 - log and continue polling
+                logger.warning("TrueNAS poll failed: %s", exc)
+            if self._stop.wait(interval):
+                break
+
+    def _start_k8s_watches(self, debouncer: Debouncer) -> None:
+        k8s = self._monitor.k8s_client
+        namespace = k8s.config.namespace
+
+        def watch_pv() -> None:
+            try:
+                for _event in k8s.watch_persistent_volumes(timeout_seconds=60):
+                    if self._stop.is_set():
+                        break
+                    debouncer.trigger()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("PV watch ended: %s", exc)
+                self._on_watch_failure(debouncer)
+
+        def watch_pvc() -> None:
+            try:
+                for _event in k8s.watch_persistent_volume_claims(
+                    namespace=namespace, timeout_seconds=60
+                ):
+                    if self._stop.is_set():
+                        break
+                    debouncer.trigger()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("PVC watch ended: %s", exc)
+                self._on_watch_failure(debouncer)
+
+        for target, fn in (("pv", watch_pv), ("pvc", watch_pvc)):
+            thread = threading.Thread(target=fn, name=f"watch-{target}", daemon=True)
+            thread.start()
+            self._watch_threads.append(thread)
+
+    def _on_watch_failure(self, debouncer: Debouncer) -> None:
+        if self._stop.is_set():
+            return
+        self._run_full_scan("watch_failure")
+        debouncer.trigger()
+
+    def _debounced_reconcile(self) -> None:
+        if self._stop.is_set():
+            return
+        self._invalidate_k8s_cache()
+        self._run_reconcile(trigger="debounce")
+
+    def _run_full_scan(self, trigger: str) -> None:
+        self._invalidate_all_cache()
+        self._run_reconcile(trigger=trigger)
+
+    def _run_reconcile(self, trigger: str) -> None:
+        logger.info("Running orphan reconcile (trigger=%s)", trigger)
+        try:
+            result = self._monitor.find_orphaned_resources()
+            summary = result.get("summary", {})
+            logger.info(
+                "Reconcile complete: pvs=%s pvcs=%s snapshots=%s duration=%ss",
+                summary.get("orphaned_pvs", 0),
+                summary.get("orphaned_pvcs", 0),
+                summary.get("orphaned_snapshots", 0),
+                result.get("scan_duration", 0),
+            )
+        except TrueNASMonitorError as exc:
+            logger.error("Reconcile failed: %s", exc)
+
+    def _invalidate_k8s_cache(self) -> None:
+        cache = getattr(self._monitor.k8s_client, "_inventory_cache", None)
+        if cache is not None:
+            cache.invalidate_prefix("k8s_")
+
+    def _invalidate_all_cache(self) -> None:
+        for client in (self._monitor.k8s_client, self._monitor.truenas_client):
+            cache = getattr(client, "_inventory_cache", None)
+            if cache is not None:
+                cache.clear()

--- a/python/truenas_storage_monitor/reconcile.py
+++ b/python/truenas_storage_monitor/reconcile.py
@@ -126,7 +126,9 @@ class WatchReconciler:
                 return list(self._tn_snapshot.volumes)
         return self._orig_get_volumes()
 
-    def _cached_get_snapshots(self) -> List[Any]:
+    def _cached_get_snapshots(self, dataset: Optional[str] = None) -> List[Any]:
+        if dataset is not None:
+            return self._orig_get_snapshots(dataset)
         if self._force_live_tn:
             return self._orig_get_snapshots()
         with self._tn_lock:

--- a/python/truenas_storage_monitor/reconcile.py
+++ b/python/truenas_storage_monitor/reconcile.py
@@ -16,6 +16,8 @@ from .time_utils import utc_now
 
 logger = logging.getLogger(__name__)
 
+WATCH_RESTART_BACKOFF_SECONDS = 5
+
 
 @dataclass
 class TruenasSnapshot:
@@ -42,9 +44,17 @@ class Debouncer:
                 return
             if self._timer is not None:
                 self._timer.cancel()
-            self._timer = threading.Timer(self._delay, self._fire)
-            self._timer.daemon = True
-            self._timer.start()
+
+            timer_holder: List[Optional[threading.Timer]] = [None]
+
+            def fire_fn() -> None:
+                self._fire(timer_holder[0])
+
+            timer = threading.Timer(self._delay, fire_fn)
+            timer.daemon = True
+            timer_holder[0] = timer
+            self._timer = timer
+            timer.start()
 
     def cancel(self) -> None:
         with self._lock:
@@ -53,9 +63,9 @@ class Debouncer:
                 self._timer.cancel()
                 self._timer = None
 
-    def _fire(self) -> None:
+    def _fire(self, timer: Optional[threading.Timer]) -> None:
         with self._lock:
-            if self._stopped:
+            if self._stopped or timer is None or self._timer is not timer:
                 return
         self._callback()
 
@@ -69,7 +79,15 @@ class WatchReconciler:
         self._stop = threading.Event()
         self._tn_snapshot = TruenasSnapshot()
         self._tn_lock = threading.Lock()
+        self._reconcile_lock = threading.Lock()
+        self._force_live_tn = False
         self._watch_threads: List[threading.Thread] = []
+
+        client = monitor.truenas_client
+        self._orig_get_volumes = client.get_volumes
+        self._orig_get_snapshots = client.get_snapshots
+        client.get_volumes = self._cached_get_volumes  # type: ignore[method-assign]
+        client.get_snapshots = self._cached_get_snapshots  # type: ignore[method-assign]
 
     def run_until_signal(self) -> None:
         """Block until SIGINT/SIGTERM, running watch reconcile."""
@@ -100,12 +118,28 @@ class WatchReconciler:
             debouncer.cancel()
             self._stop.set()
 
+    def _cached_get_volumes(self) -> List[Any]:
+        if self._force_live_tn:
+            return self._orig_get_volumes()
+        with self._tn_lock:
+            if self._tn_snapshot.updated_at is not None:
+                return list(self._tn_snapshot.volumes)
+        return self._orig_get_volumes()
+
+    def _cached_get_snapshots(self) -> List[Any]:
+        if self._force_live_tn:
+            return self._orig_get_snapshots()
+        with self._tn_lock:
+            if self._tn_snapshot.updated_at is not None:
+                return list(self._tn_snapshot.snapshots)
+        return self._orig_get_snapshots()
+
     def _truenas_poll_loop(self) -> None:
         interval = self._config.truenas_poll_interval.total_seconds()
         while not self._stop.is_set():
             try:
-                volumes = self._monitor.truenas_client.get_volumes()
-                snapshots = self._monitor.truenas_client.get_snapshots()
+                volumes = self._orig_get_volumes()
+                snapshots = self._orig_get_snapshots()
                 with self._tn_lock:
                     self._tn_snapshot = TruenasSnapshot(
                         volumes=list(volumes),
@@ -121,30 +155,44 @@ class WatchReconciler:
         k8s = self._monitor.k8s_client
         namespace = k8s.config.namespace
 
-        def watch_pv() -> None:
-            try:
-                for _ in k8s.watch_persistent_volumes(timeout_seconds=60):
-                    if self._stop.is_set():
-                        break
-                    debouncer.trigger()
-            except Exception as exc:  # noqa: BLE001
-                logger.warning("PV watch ended: %s", exc)
-                self._on_watch_failure(debouncer)
+        def watch_loop(
+            name: str,
+            stream_factory: Callable[[], Any],
+        ) -> None:
+            while not self._stop.is_set():
+                try:
+                    for _ in stream_factory():
+                        if self._stop.is_set():
+                            break
+                        debouncer.trigger()
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("%s watch ended: %s", name, exc)
+                    self._on_watch_failure(debouncer)
+                if self._stop.wait(WATCH_RESTART_BACKOFF_SECONDS):
+                    break
 
-        def watch_pvc() -> None:
-            try:
-                for _ in k8s.watch_persistent_volume_claims(
-                    namespace=namespace, timeout_seconds=60
-                ):
-                    if self._stop.is_set():
-                        break
-                    debouncer.trigger()
-            except Exception as exc:  # noqa: BLE001
-                logger.warning("PVC watch ended: %s", exc)
-                self._on_watch_failure(debouncer)
+        threads = [
+            (
+                "pv",
+                lambda: k8s.watch_persistent_volumes(timeout_seconds=60),
+            ),
+            (
+                "pvc",
+                lambda: k8s.watch_persistent_volume_claims(namespace=namespace, timeout_seconds=60),
+            ),
+            (
+                "snapshot",
+                lambda: k8s.watch_volume_snapshots(namespace=namespace, timeout_seconds=60),
+            ),
+        ]
 
-        for target, fn in (("pv", watch_pv), ("pvc", watch_pvc)):
-            thread = threading.Thread(target=fn, name=f"watch-{target}", daemon=True)
+        for name, stream_factory in threads:
+            thread = threading.Thread(
+                target=watch_loop,
+                args=(name, stream_factory),
+                name=f"watch-{name}",
+                daemon=True,
+            )
             thread.start()
             self._watch_threads.append(thread)
 
@@ -161,31 +209,40 @@ class WatchReconciler:
         self._run_reconcile(trigger="debounce")
 
     def _run_full_scan(self, trigger: str) -> None:
-        self._invalidate_all_cache()
-        self._run_reconcile(trigger=trigger)
+        self._force_live_tn = True
+        try:
+            self._invalidate_all_cache()
+            self._run_reconcile(trigger=trigger)
+        finally:
+            self._force_live_tn = False
 
     def _run_reconcile(self, trigger: str) -> None:
-        logger.info("Running orphan reconcile (trigger=%s)", trigger)
-        try:
-            result = self._monitor.find_orphaned_resources()
-            summary = result.get("summary", {})
-            logger.info(
-                "Reconcile complete: pvs=%s pvcs=%s snapshots=%s duration=%ss",
-                summary.get("orphaned_pvs", 0),
-                summary.get("orphaned_pvcs", 0),
-                summary.get("orphaned_snapshots", 0),
-                result.get("scan_duration", 0),
-            )
-        except TrueNASMonitorError as exc:
-            logger.error("Reconcile failed: %s", exc)
+        with self._reconcile_lock:
+            logger.info("Running orphan reconcile (trigger=%s)", trigger)
+            try:
+                result = self._monitor.find_orphaned_resources()
+                summary = result.get("summary", {})
+                logger.info(
+                    "Reconcile complete: pvs=%s pvcs=%s snapshots=%s duration=%ss",
+                    summary.get("orphaned_pvs", 0),
+                    summary.get("orphaned_pvcs", 0),
+                    summary.get("orphaned_snapshots", 0),
+                    result.get("scan_duration", 0),
+                )
+            except TrueNASMonitorError as exc:
+                logger.error("Reconcile failed: %s", exc)
+
+    @staticmethod
+    def _client_cache(client: Any) -> Any:
+        return getattr(client, "_cache", None)
 
     def _invalidate_k8s_cache(self) -> None:
-        cache = getattr(self._monitor.k8s_client, "_inventory_cache", None)
+        cache = self._client_cache(self._monitor.k8s_client)
         if cache is not None:
             cache.invalidate_prefix("k8s_")
 
     def _invalidate_all_cache(self) -> None:
         for client in (self._monitor.k8s_client, self._monitor.truenas_client):
-            cache = getattr(client, "_inventory_cache", None)
+            cache = self._client_cache(client)
             if cache is not None:
                 cache.clear()

--- a/python/truenas_storage_monitor/reconcile.py
+++ b/python/truenas_storage_monitor/reconcile.py
@@ -123,7 +123,7 @@ class WatchReconciler:
 
         def watch_pv() -> None:
             try:
-                for _event in k8s.watch_persistent_volumes(timeout_seconds=60):
+                for _ in k8s.watch_persistent_volumes(timeout_seconds=60):
                     if self._stop.is_set():
                         break
                     debouncer.trigger()
@@ -133,7 +133,7 @@ class WatchReconciler:
 
         def watch_pvc() -> None:
             try:
-                for _event in k8s.watch_persistent_volume_claims(
+                for _ in k8s.watch_persistent_volume_claims(
                     namespace=namespace, timeout_seconds=60
                 ):
                     if self._stop.is_set():


### PR DESCRIPTION
## Summary

- Adds opt-in **watch** reconcile mode (`poll` remains default) for the Go monitor: SharedInformers on PV/PVC/VolumeSnapshot, debounced orphan detection, periodic TrueNAS inventory polling, K8s cache invalidation on debounced reconcile, and new Prometheus metrics.
- Adds Python parity: `monitoring.reconcile_mode` / `debounce` / `truenas_poll_interval` config keys and `truenas-monitor watch` long-running command.
- On watch sync/runner failure: full inventory scan, then watch restart loop.

**Design:** [docs/superpowers/specs/2026-06-01-pr-11-watch-reconcile-design.md](docs/superpowers/specs/2026-06-01-pr-11-watch-reconcile-design.md)

**Plan:** [docs/superpowers/plans/2026-06-01-pr-11-watch-reconcile.md](docs/superpowers/plans/2026-06-01-pr-11-watch-reconcile.md)

## Test plan

- [x] `make go-test && make go-lint && cd go && go vet ./...`
- [x] `make python-test` (106 tests, 77.9% coverage)
- [ ] `gh pr checks` green on head commit (pending CI)
- [ ] Optional: kind smoke with `monitor.reconcile_mode: watch`

## PR checklist

- [x] **Scope:** Maps to remediation plan PR 11 (Stage 2 / M4).
- [x] **Correctness:** Unit tests for config, debouncer, TN poller, cache invalidation, metrics, Python reconcile/CLI.
- [x] **Regression Safety:** Existing poll-mode monitor loop unchanged; API server unchanged (on-demand lists only).
- [ ] **CI:** Required GitHub Actions checks green on PR head commit.
- [x] **Security:** Read-only watches/lists; no new write paths.
- [x] **Reliability:** Full scan on watch failure; debounce coalesces event storms; TN polled on separate interval.
- [x] **Performance:** Avoids per-event full K8s list when debounced; TN lists served from poller snapshot between polls.
- [x] **Docs:** `config.go.example`, `config.yaml.example`, `docs/config-compatibility.md`, plan tracking updated.
- [x] **Ops/Runbook:** Rollout/backout in design spec (set `reconcile_mode: poll` or revert).
- [x] **Verification Evidence:** Local `make go-test`, `make go-lint`, `make python-test` passed on `19359ad`.
- [x] **Tracking:** Remediation plan PR 11 marked Ready for PR; acceptance criteria checked.

## Config example (Go)

```yaml
monitor:
  reconcile_mode: watch
  debounce: 30s
  truenas_poll_interval: 5m
```

## Config example (Python)

```yaml
monitoring:
  reconcile_mode: watch
  debounce: 30s
  truenas_poll_interval: 5m
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Watch-mode reconciliation: debounced K8s event-driven reconciles, background TrueNAS snapshot polling, a new CLI "watch" command, and service APIs to run scans or full scans with selective cache invalidation.

* **Configuration**
  - New monitor settings: reconcile_mode (poll|watch), debounce, truenas_poll_interval with examples, defaults, and validation.

* **Metrics**
  - Added reconcile-related Prometheus metrics: mode, watch events, reconcile triggers, and TrueNAS snapshot age.

* **Tests**
  - New and expanded tests covering reconcile/watch, debouncer, poller, metrics, config, and CLI behavior.

* **Documentation**
  - Updated design, compatibility, plans, and rollout guidance for watch-mode.

* **Bug Fixes / Improvements**
  - Inventory cache: added targeted and full invalidation methods; K8s snapshot watch updated to v1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->