### PR TITLE
docs: align PRD with shipped baseline vs roadmap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,13 +78,13 @@ This snapshot is for contributor orientation and should be kept current as PRs m
 
 - Some API/validation paths still include placeholder or not-implemented behavior.
 - Test coverage quality is uneven due to interface drift and stale assumptions in parts of the suite.
-- Documentation has been converging toward implemented reality but still requires ongoing alignment.
+- Product PRD ([docs/PRD.md](docs/PRD.md)) separates current baseline from target roadmap; operator docs ([docs/ARCHITECTURE.md](docs/ARCHITECTURE.md), [docs/api-endpoints.md](docs/api-endpoints.md)) should stay in sync when behavior changes.
 
 ### Planned / Later Stage
 
 - Full endpoint maturity with complete end-to-end behavior guarantees.
-- Scalability upgrades (incremental/watch-driven reconciliation, smarter caching).
-- Higher operational maturity (performance budgets, resilience hardening, stronger SLO-driven operations).
+- Scalability upgrades beyond baseline watch/cache (e.g., multi-shard monitors, persistent trend store).
+- Higher operational maturity (hard SLO gates, stronger resilience automation beyond soft performance budgets).
 
 ### Contribution Guidance by Maturity
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ make docker-build-all   # monitor, api, cli images
 - [Test inventory](docs/testing/test-inventory.md) — capability-to-test traceability map
 - [Staging test runbook](docs/testing/staging-test-runbook.md) — preflight and execution for staging lane
 - [Agent test execution](docs/testing/agent-test-execution.md) — autonomous test sequence and stop conditions
-- [PRD](docs/PRD.md) — Product requirements and roadmap
+- [PRD](docs/PRD.md) — Product requirements: **§2 current baseline** vs **§3–6 target roadmap**
 - [Remediation plan](docs/superpowers/plans/2026-05-28-repo-health-remediation.md) — Phased repo health work
 - [Backlog](docs/superpowers/backlog.md) — Canonical out-of-scope intake
 
@@ -204,7 +204,7 @@ Apache License 2.0 — see [LICENSE](LICENSE).
 
 ## Roadmap
 
-See [docs/PRD.md](docs/PRD.md) for the full roadmap. Upcoming themes include Grafana integration, auto-remediation, and multi-cluster support — none are shipped in the baseline.
+See [docs/PRD.md](docs/PRD.md) for the full product vision. **§2** lists what is shipped or partial today; **§3–§6** are roadmap. Upcoming themes include Grafana integration, auto-remediation, and multi-cluster support — not shipped in the baseline.
 
 ## Acknowledgments
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -133,7 +133,7 @@ sequenceDiagram
 | Web UI | — | — | Planned |
 | Go controller | — | — | Not in repo |
 
-Configuration schemas differ between Go (`kubernetes:`) and Python (`openshift:`). See [config-compatibility.md](config-compatibility.md).
+Configuration schemas differ between Go (`kubernetes:`) and Python (`openshift:`). See [config-compatibility.md](config-compatibility.md). Product maturity summary: [PRD.md](PRD.md) §2 (baseline) and §3–6 (roadmap).
 
 ### Supported cardinality envelope (current baseline)
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -82,14 +82,14 @@ Aligned with [ARCHITECTURE.md](ARCHITECTURE.md#supported-cardinality-envelope-cu
 - Target scan duration: **under 5 minutes** in representative CI/dev environments
 - Performance budgets (`performance.budgets.*`): **warnings and metrics on breach** (soft gate), not hard failure
 
-Roadmap targets (10,000+ volumes, sub-second API at scale) are in [§5.2](#52-performance-metrics-roadmap).
+Roadmap targets (10,000+ volumes, sub-second API at scale) are in [§5.2](#52-performance-metrics).
 
 ### 2.4 Baseline compatibility
 
 - OpenShift 4.10+ / Kubernetes 1.24+
 - TrueNAS Scale 22.12+
 - Democratic-CSI 1.7+
-- Python 3.10+ / **Go 1.24+**
+- Python 3.10+ / **Go 1.25.0+** (matches `go/go.mod`; use `GOTOOLCHAIN=auto` or install Go 1.25+ locally)
 
 Go and Python use **different config schemas** (`kubernetes:` vs `openshift:`). See [config-compatibility.md](config-compatibility.md).
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,360 +1,433 @@
 # Product Requirements Document (PRD)
 # Kubernetes TrueNAS Democratic Tool
 
-## 1. Executive Summary
+> **How to read this document:** Sections through **§2 Current baseline** describe what is **shipped or partially shipped today**. **§3–§6** are **target roadmap** requirements for later releases. Maintainer detail lives in [ARCHITECTURE.md](ARCHITECTURE.md) and [api-endpoints.md](api-endpoints.md).
 
-### 1.1 Product Vision
-A comprehensive monitoring and management tool that bridges the gap between OpenShift/Kubernetes, TrueNAS Scale, and democratic-csi, providing organizations with real-time visibility, automated issue detection, and actionable insights for their persistent storage infrastructure.
+## 0. Documentation maturity model
 
-### 1.2 Problem Statement
-Organizations using OpenShift/Kubernetes with TrueNAS Scale storage via democratic-csi face significant operational challenges:
-- No unified view across the three systems
-- Manual detection of orphaned resources wastes storage and money
-- Configuration drift goes unnoticed until failures occur
-- Lack of proactive monitoring leads to preventable outages
-- No automated compliance checking for storage best practices
+| Label | Meaning |
+|-------|---------|
+| **Implemented** | Available in the baseline repository with real behavior (not demo/501). |
+| **Partial** | Some behavior exists; gaps remain (scaffold CLI, subset of API routes, soft-gate metrics only). |
+| **Planned** | Roadmap intent; not production-ready in the baseline repo. |
 
-### 1.3 Solution Overview
-An open-source, security-first tool that:
-- Continuously monitors the entire storage stack
-- Automatically detects and reports configuration issues
-- Identifies orphaned resources across all systems
-- Provides actionable recommendations
-- Enables automated remediation workflows
-- Delivers enterprise-grade security and compliance
+Do not treat **Planned** or HTTP **501** endpoints as production capabilities. See [§8 Documentation honesty guardrails](#8-documentation-honesty-guardrails).
 
-## 2. Target Users
+---
 
-### 2.1 Primary Users
-1. **Platform Engineers**
-   - Need: Unified monitoring across storage stack
-   - Pain: Manual correlation of issues across systems
-   - Value: Automated detection and remediation
+## 1. Executive summary
 
-2. **Storage Administrators**
-   - Need: Efficient storage utilization and capacity planning
-   - Pain: Hidden orphaned resources consuming capacity
-   - Value: Storage optimization and cost savings
+### 1.1 Product vision
 
-3. **DevOps Teams**
-   - Need: Reliable persistent storage for applications
-   - Pain: Storage-related application failures
-   - Value: Proactive issue prevention
+A monitoring and management tool that bridges OpenShift/Kubernetes, TrueNAS Scale, and democratic-csi—giving operators visibility, issue detection, and actionable insights for persistent storage.
 
-### 2.2 Secondary Users
-1. **Security Teams** - Compliance and audit reporting
-2. **Finance Teams** - Storage cost optimization
-3. **Application Developers** - Storage performance insights
+### 1.2 Problem statement
 
-## 3. Key Features & Requirements
+Organizations using OpenShift/Kubernetes with TrueNAS Scale via democratic-csi face operational challenges:
 
-### 3.1 Core Monitoring Features
+- No unified view across Kubernetes, TrueNAS, and CSI layers
+- Manual orphan detection wastes capacity and time
+- Configuration drift surfaces late, often at failure time
+- Limited proactive monitoring and compliance signal for storage practices
 
-#### 3.1.1 Orphaned Resource Detection
-**Priority: P0**
+### 1.3 Solution overview
+
+An open-source, security-first tool that (at full maturity) will:
+
+- Monitor the storage stack continuously
+- Detect and report configuration and orphan issues
+- Correlate Kubernetes intent with TrueNAS reality
+- Provide actionable recommendations
+- Support safe, approval-gated remediation workflows (**Planned**)
+- Meet enterprise security and compliance expectations (**Partial** today; see baseline)
+
+**Today (baseline):** orphan detection via Go monitor and API, connectivity validation, Prometheus metrics, and incremental watch/cache/performance guardrails. See [§2 Current baseline](#2-current-baseline-shipped-now).
+
+---
+
+## 2. Current baseline (shipped now)
+
+Canonical operator architecture: [ARCHITECTURE.md](ARCHITECTURE.md) (current section). API route truth: [api-endpoints.md](api-endpoints.md).
+
+### 2.1 Shipped components
+
+| Component | Path | Maturity | Role |
+|-----------|------|----------|------|
+| Monitor service | `go/cmd/monitor` | **Implemented** | Periodic K8s/TrueNAS scans, orphan metrics, optional watch mode, TTL cache, soft performance budgets |
+| API server | `go/cmd/api-server` | **Partial** | REST API; **7 routes implemented**, **15 return HTTP 501** |
+| Orphan detector | `go/pkg/orphan/` | **Implemented** | Correlates PV handles with TrueNAS volumes/snapshots |
+| Python library | `python/truenas_storage_monitor/` | **Implemented** | Config, clients, monitor module |
+| Python CLI | `python/truenas_storage_monitor/cli.py` | **Partial** | Commands exist; **scaffold** output (demo/TODO)—does not call Go API |
+| K8s manifests | `deploy/kubernetes/` | **Implemented** | Deployments, services, RBAC, ConfigMap |
+| Container images | `deploy/docker/Dockerfile.{monitor,api,cli}` | **Implemented** | Built by CI/release workflow |
+
+**Not in baseline repo:** Web UI, Helm chart, Go controller, Redis cache, gRPC layer, notification integrations, auto-remediation APIs.
+
+### 2.2 What operators can use today
+
+| Capability | How | Maturity |
+|------------|-----|----------|
+| Orphan detection (aggregate + PV subset) | `GET /api/v1/orphans`, `GET /api/v1/orphans/pvs` | **Partial** |
+| List PVs / TrueNAS volumes | `GET /api/v1/resources/pvs`, `GET /api/v1/truenas/volumes` | **Implemented** (list only) |
+| Connectivity validation | `GET /api/v1/validate`, `GET /ready` | **Partial** (connectivity; not full config audit) |
+| Background monitoring + Prometheus | Go monitor service | **Implemented** |
+| TLS to TrueNAS (secure-by-default) | Config `truenas.insecure: false`, optional `ca_file` | **Implemented** |
+| Production orphan checks via Python CLI | Not recommended | **Partial**—use Go API |
+
+### 2.3 Baseline performance envelope
+
+Aligned with [ARCHITECTURE.md](ARCHITECTURE.md#supported-cardinality-envelope-current-baseline):
+
+- Initial operating envelope: roughly **1,000** PV/PVC/snapshot objects
+- Target scan duration: **under 5 minutes** in representative CI/dev environments
+- Performance budgets (`performance.budgets.*`): **warnings and metrics on breach** (soft gate), not hard failure
+
+Roadmap targets (10,000+ volumes, sub-second API at scale) are in [§5.2](#52-performance-metrics-roadmap).
+
+### 2.4 Baseline compatibility
+
+- OpenShift 4.10+ / Kubernetes 1.24+
+- TrueNAS Scale 22.12+
+- Democratic-CSI 1.7+
+- Python 3.10+ / **Go 1.24+**
+
+Go and Python use **different config schemas** (`kubernetes:` vs `openshift:`). See [config-compatibility.md](config-compatibility.md).
+
+### 2.5 Testing and verification (baseline)
+
+- CI gate: `make test-ci-gate`, `make ci-precheck`
+- Staging lane: `make test-staging` (requires `TEST_STAGING=true`) — [staging-test-runbook.md](testing/staging-test-runbook.md)
+- Release matrix: `make test-release-matrix` — [test-inventory.md](testing/test-inventory.md)
+
+---
+
+## 3. Target roadmap — key features and requirements
+
+The subsections below describe **product goals for future releases**. Each lists **roadmap maturity** (target state) and **target acceptance criteria** unless noted as already partially met in §2.
+
+### 3.1 Core monitoring features
+
+#### 3.1.1 Orphaned resource detection
+
+**Roadmap priority:** P0 | **Baseline maturity:** **Partial**
+
+**Target capabilities:**
+
 - Detect PVs without corresponding TrueNAS volumes
-- Identify TrueNAS volumes without OpenShift PVs
+- Identify TrueNAS volumes without Kubernetes PVs
 - Find unbound PVCs older than configurable threshold
 - Locate stale volume attachments
-- Track orphaned snapshots across systems
+- Track orphaned snapshots across systems (API routes for PVC/snapshot orphans still **Planned**)
 
-**Acceptance Criteria:**
+**Target acceptance criteria (GA):**
+
 - Detection accuracy > 99.9%
-- Scan completion < 5 minutes for 1000 volumes
-- Zero false positives for active resources
+- Scan completion < 5 minutes for 1,000 volumes (baseline envelope today)
+- Near-zero false positives for active resources
 
-#### 3.1.2 Snapshot Management
-**Priority: P0**
+#### 3.1.2 Snapshot management
+
+**Roadmap priority:** P0 | **Baseline maturity:** **Planned**
+
+**Target capabilities:**
+
 - Track snapshot count and growth per volume
 - Map TrueNAS snapshots to VolumeSnapshot objects
 - Monitor snapshot age and retention compliance
 - Detect failed or stuck snapshot operations
 - Calculate snapshot storage consumption
 
-**Acceptance Criteria:**
-- Real-time snapshot tracking (< 1 minute lag)
+**Target acceptance criteria (GA):**
+
+- Snapshot tracking lag < 1 minute
 - Support for 10,000+ snapshots per cluster
 - Automated retention policy enforcement
 
-#### 3.1.3 Configuration Validation
-**Priority: P0**
+#### 3.1.3 Configuration validation
+
+**Roadmap priority:** P0 | **Baseline maturity:** **Partial** (`GET /api/v1/validate` connectivity only)
+
+**Target capabilities:**
+
 - Validate StorageClass against TrueNAS capabilities
-- Verify CSI driver health across all nodes
-- Check RBAC permissions completeness
+- Verify CSI driver health across nodes
+- Check RBAC completeness
 - Validate snapshot class configurations
 - Ensure retention policy alignment
 
-**Acceptance Criteria:**
-- 100% coverage of critical configuration items
-- Validation runs complete < 30 seconds
-- Clear remediation steps for each issue
+**Target acceptance criteria (GA):**
 
-### 3.2 Analysis & Intelligence
+- Coverage of critical configuration items
+- Validation runs < 30 seconds
+- Clear remediation steps per finding
 
-#### 3.2.1 Storage Usage Analytics
-**Priority: P1**
-- Compare allocated vs actual storage usage
-- Track thin provisioning efficiency
-- Monitor pool overcommitment levels
-- Identify volumes approaching capacity
-- Calculate storage savings metrics
+### 3.2 Analysis and intelligence
 
-**Acceptance Criteria:**
-- Accuracy within 1% of actual usage
-- Historical trending for 90+ days
-- Predictive alerts 7 days before capacity issues
+#### 3.2.1 Storage usage analytics
 
-#### 3.2.2 Performance Monitoring
-**Priority: P1**
-- Volume provisioning time tracking
-- Mount/unmount operation metrics
-- Snapshot creation/deletion performance
-- TrueNAS pool performance metrics
-- End-to-end operation latency
+**Roadmap priority:** P1 | **Baseline maturity:** **Planned** (all `/api/v1/analysis/*` return 501)
 
-**Acceptance Criteria:**
-- Metrics collection every 30 seconds
-- P95 latency tracking for all operations
-- Anomaly detection for performance degradation
+**Target capabilities:** Allocated vs used comparison, thin-provisioning efficiency, pool overcommitment, capacity warnings, savings metrics.
 
-### 3.3 Security & Compliance
+**Target acceptance criteria (GA):** Accuracy within 1% of actual usage; 90+ day trending; predictive alerts 7 days ahead.
 
-#### 3.3.1 Zero-Trust Architecture
-**Priority: P0**
-- mTLS for all communications
-- Principle of least privilege RBAC
-- No hardcoded credentials
-- Audit logging for all operations
-- Secret rotation support
+#### 3.2.2 Performance monitoring
 
-**Acceptance Criteria:**
-- Pass security audit with zero critical findings
-- Support for external secret managers
-- Complete audit trail with no gaps
+**Roadmap priority:** P1 | **Baseline maturity:** **Partial** (Prometheus + soft budgets)
 
-#### 3.3.2 Compliance Reporting
-**Priority: P1**
-- Storage encryption status
-- Access control compliance
-- Backup verification reports
-- Retention policy adherence
-- Custom compliance frameworks
+**Target capabilities:** Provisioning/mount/snapshot latency, pool metrics, end-to-end latency, anomaly detection.
 
-**Acceptance Criteria:**
-- Generate reports in < 5 minutes
-- Support PDF, HTML, JSON formats
-- Schedule automated reports
+**Target acceptance criteria (GA):** Metrics every 30s; P95 tracking; automated degradation detection.
 
-### 3.4 Integration & Automation
+### 3.3 Security and compliance
 
-#### 3.4.1 Notification Systems
-**Priority: P1**
-- Slack/Teams webhooks
-- Email notifications
-- PagerDuty integration
-- Custom webhook support
-- Severity-based routing
+#### 3.3.1 Zero-trust architecture
 
-**Acceptance Criteria:**
-- Notification delivery < 30 seconds
-- Support for notification templates
-- Escalation policy support
+**Roadmap priority:** P0 | **Baseline maturity:** **Partial** (TLS secure-by-default to TrueNAS; no full mTLS/audit stack)
 
-#### 3.4.2 Auto-Remediation
-**Priority: P2**
-- Automated orphan cleanup (with approval)
-- Snapshot pruning workflows
-- Configuration drift correction
-- Capacity rebalancing
-- Failed operation retry
+**Target capabilities:** mTLS everywhere, least-privilege RBAC, no hardcoded credentials, audit logging, secret rotation.
 
-**Acceptance Criteria:**
-- Approval workflow integration
-- Dry-run mode for all operations
-- Rollback capability
-- Detailed operation logs
+**Target acceptance criteria (GA):** Security audit with zero critical findings; external secret managers; complete audit trail.
 
-### 3.5 User Interfaces
+#### 3.3.2 Compliance reporting
 
-#### 3.5.1 Command Line Interface
-**Priority: P0**
-- Intuitive command structure
-- Multiple output formats (table, json, yaml)
-- Interactive troubleshooting mode
-- Shell completion support
-- Scriptable operations
+**Roadmap priority:** P1 | **Baseline maturity:** **Planned**
 
-**Acceptance Criteria:**
-- Commands complete < 10 seconds
-- Consistent command syntax
-- Comprehensive help system
+**Target capabilities:** Encryption status, access control reports, backup verification, retention adherence, custom frameworks.
+
+**Target acceptance criteria (GA):** Reports in < 5 minutes; PDF/HTML/JSON; scheduled delivery.
+
+### 3.4 Integration and automation
+
+#### 3.4.1 Notification systems
+
+**Roadmap priority:** P1 | **Baseline maturity:** **Planned**
+
+**Target capabilities:** Slack/Teams, email, PagerDuty, webhooks, severity routing.
+
+**Target acceptance criteria (GA):** Delivery < 30 seconds; templates; escalation policies.
+
+#### 3.4.2 Auto-remediation
+
+**Roadmap priority:** P2 | **Baseline maturity:** **Planned**
+
+**Target capabilities:** Approved orphan cleanup, snapshot pruning, drift correction, capacity rebalance, safe retries.
+
+**Target acceptance criteria (GA):** Approval workflows; dry-run; rollback; detailed logs.
+
+### 3.5 User interfaces
+
+#### 3.5.1 Command line interface
+
+**Roadmap priority:** P0 | **Baseline maturity:** **Partial** (scaffold)
+
+**Target capabilities:** Rich output formats, interactive troubleshooting, shell completion, scriptable operations with live data.
+
+**Target acceptance criteria (GA):** Commands < 10 seconds; consistent syntax; comprehensive help.
 
 #### 3.5.2 REST API
-**Priority: P0**
-- OpenAPI 3.0 specification
-- Authentication via tokens
-- Rate limiting per client
-- Webhook endpoints
-- WebSocket for real-time data
 
-**Acceptance Criteria:**
-- API response time < 500ms
-- 99.9% availability
-- Backward compatibility
+**Roadmap priority:** P0 | **Baseline maturity:** **Partial** (7/22 routes; per-client rate limiting shipped)
 
-#### 3.5.3 Web Dashboard
-**Priority: P2**
-- Real-time metrics display
-- Historical trending charts
-- Alert management interface
-- Report generation UI
-- Mobile-responsive design
+**Target capabilities:** OpenAPI 3.0, token auth, webhooks, WebSocket streaming.
 
-**Acceptance Criteria:**
-- Page load time < 2 seconds
-- Support 100+ concurrent users
-- Accessibility WCAG 2.1 AA compliant
+**Target acceptance criteria (GA):** p95 < 500ms for implemented routes at baseline scale; high availability; backward compatibility.
 
-## 4. Technical Requirements
+#### 3.5.3 Web dashboard
 
-### 4.1 Architecture
-- **Hybrid Go/Python** implementation
-- **Microservices** architecture
-- **Cloud-native** design principles
-- **Horizontal scaling** support
-- **High availability** deployment option
+**Roadmap priority:** P2 | **Baseline maturity:** **Planned**
 
-### 4.2 Performance
-- Monitor 10,000+ volumes without degradation
-- Process 1M+ metrics per minute
-- Sub-second API response times
-- Minimal resource footprint (< 500MB RAM base)
+**Target capabilities:** Live metrics, trends, alerts UI, reports, mobile-responsive WCAG 2.1 AA.
 
-### 4.3 Compatibility
-- OpenShift 4.10+
-- Kubernetes 1.24+
-- TrueNAS Scale 22.12+
-- Democratic-CSI 1.7+
-- Python 3.10+ / Go 1.21+
+**Target acceptance criteria (GA):** Page load < 2s; 100+ concurrent users.
 
-### 4.4 Deployment Options
-1. **Standalone Binary** - Single-node deployments
-2. **Container** - Docker/Podman compatible
-3. **Kubernetes Operator** - Automated lifecycle management
-4. **Helm Chart** - Customizable deployment
+---
 
-## 5. Success Metrics
+## 4. Target roadmap — technical requirements
 
-### 5.1 Adoption Metrics
+### 4.1 Architecture (target)
+
+- Hybrid Go/Python (**Implemented** layout; full microservices/HA **Planned**)
+- Cloud-native design principles
+- Horizontal scaling and HA deployment options (**Planned**—see [ARCHITECTURE.md](ARCHITECTURE.md) target sections)
+
+### 4.2 Performance (target)
+
+| Scope | Target |
+|-------|--------|
+| **Baseline (today)** | ~1,000 objects; scan < 5 min; soft performance budgets |
+| **Roadmap (GA)** | 10,000+ volumes; 1M+ metrics/min; sub-second API at scale; < 500MB RAM base |
+
+### 4.3 Compatibility (target)
+
+Same as [§2.4](#24-baseline-compatibility); maintain version matrix as integrations evolve.
+
+### 4.4 Deployment options
+
+| Option | Baseline maturity |
+|--------|-------------------|
+| Standalone binary | **Implemented** |
+| Container images | **Implemented** |
+| Kubernetes manifests (`deploy/kubernetes/`) | **Implemented** |
+| Kubernetes Operator | **Planned** |
+| Helm chart | **Planned** (backlog) |
+
+---
+
+## 5. Success metrics
+
+### 5.1 Adoption metrics (roadmap)
+
+Community and adoption goals for post-baseline releases—not current release gates:
+
 - 100+ production deployments in 6 months
 - 1,000+ GitHub stars in 12 months
 - 50+ active contributors
 - 10+ enterprise adoptions
 
-### 5.2 Performance Metrics
-- 99.9% detection accuracy
-- < 5 minute scan time for 1,000 volumes
-- < 1% false positive rate
-- 90%+ automated issue resolution
+### 5.2 Performance metrics
 
-### 5.3 Business Impact
-- 30% reduction in storage-related incidents
-- 20% improvement in storage utilization
-- 50% faster MTTR for storage issues
-- $100K+ annual savings per deployment
+| Metric | Baseline (today) | Roadmap (GA) |
+|--------|------------------|--------------|
+| Detection accuracy | Improving; not yet 99.9% gate | > 99.9% |
+| Scan time (1k volumes) | Target < 5 min (soft budgets) | Same + scale to 10k+ |
+| False positive rate | Operator validation | < 1% |
+| Automated resolution | N/A | 90%+ where auto-remediation ships |
 
-## 6. Release Plan
+### 5.3 Business impact (roadmap)
 
-### 6.1 MVP (v0.1.0) - Month 1-2
-- Core monitoring functionality
-- Orphan detection
-- CLI interface
-- Basic notifications
+Targets for mature product adoption: fewer storage incidents, better utilization, faster MTTR, measurable cost savings per deployment.
 
-### 6.2 Beta (v0.5.0) - Month 3-4
-- Snapshot management
-- REST API
-- Integration tests
-- Documentation
+---
 
-### 6.3 GA (v1.0.0) - Month 5-6
-- Auto-remediation
-- Web dashboard
-- Enterprise features
-- Production hardening
+## 6. Release plan (roadmap milestones)
 
-### 6.4 Future Releases
-- v1.1.0 - ML-based predictions
-- v1.2.0 - Multi-cluster support
-- v2.0.0 - Plugin architecture
+> **Note:** Milestones below are **sequencing intent**, not a claim about the current repository version. Baseline behavior is described in [§2](#2-current-baseline-shipped-now).
 
-## 7. Risks & Mitigations
+### 6.1 MVP (v0.1.0) — baseline themes
 
-### 7.1 Technical Risks
+- Core monitoring and orphan detection (Go monitor + partial API) — **Partial / Implemented**
+- CLI interface — **Partial** (scaffold)
+- Basic notifications — **Planned**
+
+### 6.2 Beta (v0.5.0)
+
+- Snapshot management APIs and workflows — **Planned**
+- REST API breadth (beyond 7 routes) — **Partial** today
+- Integration and staging test depth — **In progress** ([test-inventory.md](testing/test-inventory.md))
+
+### 6.3 GA (v1.0.0)
+
+- Auto-remediation — **Planned**
+- Web dashboard — **Planned**
+- Enterprise hardening (SLOs, full validation, compliance reports)
+
+### 6.4 Future releases
+
+- v1.1.0 — ML-based predictions (**Planned**)
+- v1.2.0 — Multi-cluster support (**Planned**)
+- v2.0.0 — Plugin architecture (**Planned**)
+
+---
+
+## 7. Target users
+
+### 7.1 Primary users
+
+1. **Platform engineers** — unified monitoring; today: Go API/monitor orphan paths
+2. **Storage administrators** — capacity and orphan visibility; today: metrics + API lists
+3. **DevOps teams** — reliable storage operations; today: validation and detection signal
+
+### 7.2 Secondary users
+
+Security, finance, and application teams gain full value as compliance, cost, and performance features move from **Planned** to **Implemented**.
+
+---
+
+## 8. Documentation honesty guardrails
+
+For contributors and technical writers:
+
+1. Label every user-visible capability **Implemented**, **Partial**, or **Planned** in PRD and operator docs.
+2. Do not describe HTTP **501** routes or scaffold CLI output as production-ready.
+3. Keep [api-endpoints.md](api-endpoints.md) synchronized with `go/pkg/api/server.go`.
+4. Prefer linking to [ARCHITECTURE.md](ARCHITECTURE.md) for design detail rather than duplicating target diagrams in PRD.
+5. When roadmap scope changes, update this PRD and the relevant spec under `docs/superpowers/specs/` before implementation.
+
+Related docs: [AGENTS.md](../AGENTS.md), [config-compatibility.md](config-compatibility.md), [remediation plan](superpowers/plans/2026-05-28-repo-health-remediation.md).
+
+---
+
+## 9. Risks and mitigations
+
+### 9.1 Technical risks
+
 | Risk | Impact | Mitigation |
 |------|--------|------------|
 | API breaking changes | High | Version detection, compatibility matrix |
-| Performance at scale | Medium | Horizontal scaling, caching layer |
-| Security vulnerabilities | High | Regular audits, dependency scanning |
+| Performance at scale | Medium | Caching, watch reconcile, performance budgets (baseline); horizontal scaling (roadmap) |
+| Security vulnerabilities | High | Audits, dependency scanning, TLS defaults |
 
-### 7.2 Adoption Risks
+### 9.2 Adoption risks
+
 | Risk | Impact | Mitigation |
 |------|--------|------------|
-| Complex deployment | Medium | Operator pattern, good documentation |
-| Learning curve | Low | Video tutorials, examples |
-| Enterprise requirements | Medium | Modular architecture, paid support |
+| Complex deployment | Medium | Clear docs; Helm/operator later |
+| Learning curve | Low | Examples, runbooks |
+| Enterprise requirements | Medium | Modular architecture; optional support |
 
-## 8. Open Source Strategy
+---
 
-### 8.1 License
+## 10. Open source strategy
+
+### 10.1 License
+
 - Apache 2.0 License
-- CLA for contributors
-- No proprietary dependencies
+- CLA for contributors when required
+- No proprietary dependencies in baseline
 
-### 8.2 Community Building
-- Public roadmap
-- Regular release cycle
-- Community meetings
-- Contribution guidelines
+### 10.2 Community building
+
+- Public roadmap (this PRD + remediation plan)
+- Regular releases and contribution guidelines
 - Code of conduct
 
-### 8.3 Governance
-- Maintainer team
-- Technical steering committee
-- Security team
-- Documentation team
+### 10.3 Governance
 
-## 9. Competitive Analysis
+Maintainer, security, and documentation responsibilities per [AGENTS.md](../AGENTS.md) and project norms.
 
-### 9.1 Existing Solutions
-| Solution | Strengths | Weaknesses | Our Advantage |
+---
+
+## 11. Competitive analysis
+
+### 11.1 Existing solutions
+
+| Solution | Strengths | Weaknesses | Our advantage |
 |----------|-----------|------------|---------------|
-| Manual Scripts | Free, customizable | Not scalable, error-prone | Automated, reliable |
-| Generic Monitoring | Mature, feature-rich | Not storage-specific | Purpose-built |
-| Vendor Tools | Integrated, supported | Vendor lock-in, expensive | Open source, flexible |
+| Manual scripts | Free, customizable | Not scalable | Purpose-built correlation |
+| Generic monitoring | Mature | Not storage-specific | K8s + TrueNAS + CSI focus |
+| Vendor tools | Integrated | Lock-in, cost | Open source, flexible |
 
-### 9.2 Unique Value Proposition
-1. **Only tool** specifically for OpenShift + TrueNAS + democratic-csi
-2. **Security-first** design with zero-trust architecture
-3. **True idempotency** for safe automation
-4. **Hybrid architecture** balancing performance and flexibility
-5. **Open source** with enterprise features
+### 11.2 Unique value proposition (full vision)
 
-## 10. Resource Requirements
+1. Purpose-built for OpenShift/Kubernetes + TrueNAS + democratic-csi
+2. Security-first design (baseline: TLS defaults; roadmap: full zero-trust)
+3. Idempotent, safe automation (**Planned** remediation)
+4. Hybrid Go/Python architecture (**Implemented** split)
+5. Open source with a path to enterprise depth
 
-### 10.1 Development Team
-- 2 Senior Engineers (Go/Python)
-- 1 DevOps Engineer
-- 1 Technical Writer
-- 0.5 Product Manager
+---
 
-### 10.2 Timeline
-- 6 months to GA
-- 12 months to feature complete
-- Ongoing maintenance
+## 12. Resource requirements (planning)
 
-### 10.3 Budget
-- Development: Open source contributors
-- Infrastructure: GitHub free tier
-- Marketing: Community-driven
-- Support: Optional paid tiers
+### 12.1 Development team (illustrative)
+
+- Senior engineers (Go/Python), DevOps, technical writing, part-time product ownership
+
+### 12.2 Timeline (roadmap)
+
+- Phased delivery via remediation plan and Stage 2–5 items—not fixed calendar commitments in baseline repo
+
+### 12.3 Budget
+
+Open-source contribution model; infrastructure primarily GitHub Actions; optional support tiers **Planned**.

--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -2,7 +2,7 @@
 
 This document describes the current maturity of HTTP routes exposed by the Go API server (`cmd/api-server`).
 
-Orphan detection runs synchronously on each request for implemented orphan routes. Detection quality continues to improve in PR-5 (detector fidelity).
+Orphan detection runs synchronously on each request for implemented orphan routes. Detector fidelity improvements land in focused PRs with tests; see [ARCHITECTURE.md](ARCHITECTURE.md) and [PRD.md](PRD.md) for maturity context.
 
 ## Infrastructure
 

--- a/docs/superpowers/plans/2026-05-28-repo-health-remediation.md
+++ b/docs/superpowers/plans/2026-05-28-repo-health-remediation.md
@@ -473,9 +473,10 @@ Suggested worktree layout:
 
 ### Stage 5: Documentation Governance
 
+- [x] PRD maturity alignment (baseline vs roadmap) — spec `docs/superpowers/specs/2026-06-03-prd-maturity-alignment-design.md`; deferred from PR 8 scope
 - [ ] Add docs ownership and docs-impact checklist to PR template.
 - [ ] Add docs-lint checks for path/command validity in CI.
-- [ ] Version documentation by maturity/release channel.
+- [ ] Version documentation by maturity/release channel (full automation).
 
 ## Sequencing
 
@@ -490,6 +491,11 @@ Suggested worktree layout:
 - [x] Complete PR 10 (TTL inventory cache).
 - [x] Complete PR 11 (watch/incremental reconcile).
 - [x] Complete PR 12 (performance budgets).
+
+## Execution Notes (2026-06-03)
+
+- PRD alignment (docs-only, local): `docs/PRD.md` restructured per `docs/superpowers/specs/2026-06-03-prd-maturity-alignment-design.md` — closes PR 8 deferral for product-facing maturity labels
+- Spec: [2026-06-03-prd-maturity-alignment-design.md](../specs/2026-06-03-prd-maturity-alignment-design.md)
 
 ## Execution Notes (2026-06-02)
 

--- a/docs/superpowers/plans/2026-05-28-repo-health-remediation.md
+++ b/docs/superpowers/plans/2026-05-28-repo-health-remediation.md
@@ -494,8 +494,9 @@ Suggested worktree layout:
 
 ## Execution Notes (2026-06-03)
 
-- PRD alignment (docs-only, local): `docs/PRD.md` restructured per `docs/superpowers/specs/2026-06-03-prd-maturity-alignment-design.md` — closes PR 8 deferral for product-facing maturity labels
+- PRD alignment (docs-only): `docs/PRD.md` restructured per `docs/superpowers/specs/2026-06-03-prd-maturity-alignment-design.md` — closes PR 8 deferral for product-facing maturity labels
 - Spec: [2026-06-03-prd-maturity-alignment-design.md](../specs/2026-06-03-prd-maturity-alignment-design.md)
+- PR URL: https://github.com/tomazb/kubernetes-truenas-democratic-tool/pull/74
 
 ## Execution Notes (2026-06-02)
 

--- a/docs/superpowers/specs/2026-06-03-prd-maturity-alignment-design.md
+++ b/docs/superpowers/specs/2026-06-03-prd-maturity-alignment-design.md
@@ -1,0 +1,67 @@
+# PRD Maturity Alignment — Design Spec
+
+**Date:** 2026-06-03  
+**Plan item:** PRD alignment (deferred from [PR 8](2026-05-28-pr-8-docs-accuracy-design.md))  
+**Milestone:** M3 — Operational Readiness (product documentation honesty)
+
+## Problem statement and scope
+
+`docs/PRD.md` describes a full enterprise product (P0 CLI/API, real-time snapshots, zero-trust everywhere, auto-remediation) without distinguishing what is **shipped today** from **roadmap intent**. Operator docs ([ARCHITECTURE.md](../../ARCHITECTURE.md), [README.md](../../../README.md), [api-endpoints.md](../../api-endpoints.md)) were aligned in PR 8; PRD was explicitly out of scope.
+
+**In scope:**
+
+- Restructure `docs/PRD.md` with maturity model, current baseline, and target roadmap sections
+- Tag roadmap features with **Implemented**, **Partial**, or **Planned**
+- Cross-link maintainer/operator docs; light README and AGENTS.md pointer updates
+- Fix stale PR reference in `docs/api-endpoints.md`
+- Add execution note to remediation plan
+
+**Out of scope:**
+
+- ARCHITECTURE.md rewrite (already current)
+- Code, API implementation, CLI logic
+- Docs-lint CI (Stage 5 backlog)
+
+## Current vs target behavior
+
+| Area | Before | After |
+|------|--------|-------|
+| PRD structure | Single vision doc | §0 maturity + §2 baseline + §3–6 roadmap |
+| Feature claims | Implied shipped | Explicit Partial/Planned per feature |
+| Performance | 10k volumes / sub-second API as norm | Baseline envelope (~1k objects, &lt;5 min scan) + GA targets separated |
+| Release plan | Reads as current schedule | Labeled roadmap milestones |
+| Go version | 1.21+ | 1.24+ |
+
+## Shipped baseline (source of truth)
+
+| Component | Maturity |
+|-----------|----------|
+| Go monitor | Implemented |
+| Go API (7 routes) | Partial |
+| Go orphan detector | Implemented |
+| Python library | Implemented |
+| Python CLI | Partial (scaffold) |
+| K8s manifests, Docker images | Implemented |
+| Helm, controller, Web UI, Redis/gRPC | Planned |
+
+See [api-endpoints.md](../../api-endpoints.md) for route-level truth.
+
+## Technical approach
+
+1. Write this spec.
+2. Rewrite `docs/PRD.md` per plan structure.
+3. Update README, AGENTS.md, remediation plan, api-endpoints intro line.
+
+## Test strategy
+
+```bash
+make ci-precheck
+```
+
+Manual: PRD baseline table vs ARCHITECTURE shipped section; API counts vs api-endpoints.md.
+
+## Rollout and backout
+
+**Rollout:** Merge docs PR; PRD becomes product-facing maturity source linked from README.
+
+**Backout:** Revert PR; restores pre-alignment PRD.

--- a/docs/superpowers/specs/2026-06-03-prd-maturity-alignment-design.md
+++ b/docs/superpowers/specs/2026-06-03-prd-maturity-alignment-design.md
@@ -30,7 +30,7 @@
 | Feature claims | Implied shipped | Explicit Partial/Planned per feature |
 | Performance | 10k volumes / sub-second API as norm | Baseline envelope (~1k objects, &lt;5 min scan) + GA targets separated |
 | Release plan | Reads as current schedule | Labeled roadmap milestones |
-| Go version | 1.21+ | 1.24+ |
+| Go version | 1.21+ | 1.25.0+ (matches `go/go.mod`) |
 
 ## Shipped baseline (source of truth)
 


### PR DESCRIPTION
## Summary

- Restructures `docs/PRD.md` with **Implemented / Partial / Planned** labels, a **§2 current baseline** (what operators can use today), and **§3–§6 target roadmap** (deferred from PR 8 scope).
- Adds design spec `docs/superpowers/specs/2026-06-03-prd-maturity-alignment-design.md`.
- Cross-links README, AGENTS.md, ARCHITECTURE.md, and api-endpoints.md; updates remediation plan tracking.

## Spec

- [2026-06-03-prd-maturity-alignment-design.md](docs/superpowers/specs/2026-06-03-prd-maturity-alignment-design.md)

## Test plan

- [x] `make ci-precheck`
- [x] Manual crosswalk: PRD §2 vs ARCHITECTURE shipped table and api-endpoints (7 implemented, 15×501)

## PR checklist

- [x] **Scope:** Docs-only; closes PR 8 PRD deferral / Stage 5 maturity alignment item
- [x] **Correctness:** N/A (documentation)
- [x] **Regression Safety:** N/A
- [ ] **CI:** Required checks on PR head commit
- [x] **Security:** No code changes
- [x] **Reliability:** N/A
- [x] **Performance:** N/A
- [x] **Docs:** PRD, README, AGENTS, ARCHITECTURE, api-endpoints, remediation plan
- [x] **Ops/Runbook:** N/A
- [x] **Verification Evidence:** `make ci-precheck` passed locally
- [x] **Tracking:** Remediation plan execution notes updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Major rewrite and reorganization of the Product Requirements Document to separate shipped baseline from roadmap, add a maturity model, clearer acceptance criteria, and expanded component tables and metrics
  * New PRD maturity-alignment design spec and execution notes
  * Clarified README, architecture notes, API endpoint maturity, agent maturity snapshot, and roadmap/plan documents for improved status framing and guidance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->