### PR TITLE
docs: add low-risk onboarding guides and safety guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,20 @@ A monitoring and analysis tool for OpenShift/Kubernetes clusters using TrueNAS S
 
 This tool correlates Kubernetes storage objects (PVs, PVCs, snapshots) with TrueNAS datasets and volumes to detect orphaned resources, configuration drift, and storage efficiency risks.
 
+## Start here (low-risk)
+
+Use one of these onboarding paths first:
+
+- [Operator-first onboarding](docs/onboarding/operator-first.md) — safest in-cluster evaluation path with preflight, guarded deploy, and rollback guidance.
+- [Local evaluator onboarding](docs/onboarding/local-evaluator.md) — local Go API/monitor checks for iterative validation.
+
+Safety and maturity guardrails:
+
+- Use implemented routes only for onboarding (`/health`, `/ready`, `/api/v1/orphans`, `/api/v1/orphans/pvs`, `/api/v1/resources/pvs`, `/api/v1/truenas/volumes`, `/api/v1/validate`).
+- Many routes intentionally return HTTP 501 in baseline; see [API endpoint maturity](docs/api-endpoints.md).
+- Python CLI commands are scaffold/demo for several workflows; use Go API for real orphan checks.
+- `security:` config keys are parsed in Go config but not enforced by the shipped API server; keep API access internal and protected by your cluster/network controls.
+
 ### Maturity snapshot
 
 | Area | Status | Notes |
@@ -46,13 +60,13 @@ Hybrid Go/Python layout for performance-sensitive runtime paths and flexible CLI
 
 See [Architecture](docs/ARCHITECTURE.md) for current vs planned system design.
 
-## Quick Start
+## Quick Start (development/evaluation)
 
 ### Prerequisites
 
 - Kubernetes or OpenShift cluster with democratic-csi
 - TrueNAS Scale with API access
-- Go 1.24+ (for Go services)
+- Go 1.25.0+ (for Go services)
 - Python 3.10+ (for library/CLI)
 
 ### Development setup
@@ -73,7 +87,7 @@ Binaries are written to `bin/monitor` and `bin/api-server`.
 Use the Go config schema (`kubernetes:` key). See [config compatibility](docs/config-compatibility.md) and [config.go.example](config.go.example).
 
 ```bash
-export TRUENAS_USERNAME=admin
+export TRUENAS_USERNAME='service-account-name'
 export TRUENAS_PASSWORD='change-me'
 ./bin/api-server -config config.go.example -port 8080
 curl -s http://localhost:8080/health
@@ -83,6 +97,14 @@ curl -s http://localhost:8080/api/v1/orphans
 ### Deploy to Kubernetes
 
 Helm is not shipped yet. Apply the bundled manifests:
+
+Low-risk checklist before applying:
+
+- Replace placeholders in `deploy/kubernetes/secret.yaml` (`TRUENAS_URL`, `TRUENAS_USERNAME`, `TRUENAS_PASSWORD`).
+- Do not apply with `changeme` credentials.
+- Pin `truenas-monitor:latest` and `truenas-api:latest` to immutable image tags or digests.
+- Keep services internal-only (`ClusterIP`) during onboarding.
+- Keep TLS verification enabled for TrueNAS (do not uncomment `truenas.insecure` except lab-only tests).
 
 ```bash
 kubectl apply -f deploy/kubernetes/
@@ -166,6 +188,8 @@ make docker-build-all   # monitor, api, cli images
 
 - [AGENTS.md](AGENTS.md) — Contributor playbook, PR policy, verification gates
 - [Architecture](docs/ARCHITECTURE.md) — Current (shipped) vs target (planned) design
+- [Operator-first onboarding](docs/onboarding/operator-first.md) — low-risk in-cluster onboarding
+- [Local evaluator onboarding](docs/onboarding/local-evaluator.md) — low-risk local onboarding path
 - [Config compatibility](docs/config-compatibility.md) — Go vs Python YAML schemas
 - [API endpoint maturity](docs/api-endpoints.md) — Implemented vs 501 routes (7 implemented, 15 not implemented)
 - [Test inventory](docs/testing/test-inventory.md) — capability-to-test traceability map

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Low-risk checklist before applying:
 
 - Replace placeholders in `deploy/kubernetes/secret.yaml` (`TRUENAS_URL`, `TRUENAS_USERNAME`, `TRUENAS_PASSWORD`).
 - Do not apply with `changeme` credentials.
-- Pin `truenas-monitor:latest` and `truenas-api:latest` to immutable image tags or digests.
+- Replace `:latest` image references in `deploy/kubernetes/monitor-deployment.yaml` and `api-deployment.yaml` with immutable tags or digests.
 - Keep services internal-only (`ClusterIP`) during onboarding.
 - Keep TLS verification enabled for TrueNAS (do not uncomment `truenas.insecure` except lab-only tests).
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -27,6 +27,9 @@
 
 The baseline codebase ships a small set of Go services, a Python library/CLI scaffold, and Kubernetes deployment manifests. There is no Web UI, Helm chart, Redis cache, gRPC layer, or Go controller in the repository today.
 
+Use this section as the only source of deployed-baseline behavior.
+For low-risk onboarding steps, see [onboarding/operator-first.md](onboarding/operator-first.md).
+
 ### Shipped components
 
 | Component | Path | Role |
@@ -125,8 +128,8 @@ sequenceDiagram
 
 | Component | Language | Framework / library | Status |
 |-----------|----------|---------------------|--------|
-| Monitor service | Go 1.24+ | client-go, Prometheus | Shipped |
-| API server | Go 1.24+ | Gin | Shipped (partial routes) |
+| Monitor service | Go 1.25.0+ | client-go, Prometheus | Shipped |
+| API server | Go 1.25.0+ | Gin | Shipped (partial routes) |
 | Python library / CLI | Python 3.10+ | Click, Rich, kubernetes-client | Library shipped; CLI scaffold |
 | Deployment | YAML | `deploy/kubernetes/` | Shipped |
 | Helm chart | — | — | Planned (backlog) |
@@ -152,6 +155,8 @@ Performance budgets are configurable in Go runtime via `performance.budgets.*`. 
 # Target architecture (planned)
 
 > **Note:** Everything from section 1 onward describes **roadmap** components (Web UI, Controller, Redis, gRPC, ML analyzer, auto-remediation, multi-replica HA). These are **not production-ready** in the baseline repository. Diagrams are retained for planning.
+>
+> **Do not** treat this section as an implementation/deployment guide for the current repository state.
 
 ## 1. Overview
 
@@ -811,9 +816,9 @@ sequenceDiagram
 
 | Component | Language | Framework | Purpose | Status |
 |-----------|----------|-----------|---------|--------|
-| Monitor Service | Go 1.24+ | client-go | Performance-critical monitoring | Shipped |
-| API Server | Go 1.24+ | Gin | High-performance API | Shipped (partial) |
-| Controller | Go 1.24+ | controller-runtime | Kubernetes native controller | Planned (not in repo) |
+| Monitor Service | Go 1.25.0+ | client-go | Performance-critical monitoring | Shipped |
+| API Server | Go 1.25.0+ | Gin | High-performance API | Shipped (partial) |
+| Controller | Go 1.25.0+ | controller-runtime | Kubernetes native controller | Planned (not in repo) |
 | CLI Tool | Python 3.10+ | Click, Rich | User-friendly interface | Scaffold |
 | Analyzer | Python 3.10+ | Pandas, NumPy | Data analysis | Planned |
 | Web UI | TypeScript | React, Material-UI | Modern dashboard | Planned |
@@ -1097,4 +1102,11 @@ sequenceDiagram
 
 ## Conclusion
 
-This architecture provides a robust, scalable, and secure foundation for the Kubernetes TrueNAS Democratic Tool. The hybrid Go/Python approach leverages the strengths of both languages, while the microservices architecture ensures modularity and maintainability. The comprehensive security measures and idempotent design patterns make it suitable for production enterprise environments.
+For production onboarding and operational decisions in the current baseline, rely on:
+
+- the shipped section in this document,
+- [api-endpoints.md](api-endpoints.md) for implemented vs 501 routes,
+- [config-compatibility.md](config-compatibility.md) for runtime schema selection,
+- [onboarding/operator-first.md](onboarding/operator-first.md) for low-risk deployment guidance.
+
+Target architecture sections remain roadmap design material and should not be interpreted as shipped capability.

--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -4,6 +4,28 @@ This document describes the current maturity of HTTP routes exposed by the Go AP
 
 Orphan detection runs synchronously on each request for implemented orphan routes. Detector fidelity improvements land in focused PRs with tests; see [ARCHITECTURE.md](ARCHITECTURE.md) and [PRD.md](PRD.md) for maturity context.
 
+Important onboarding note:
+
+- Treat this API as an internal service during baseline onboarding.
+- The `security:` block in Go config is parsed but not enforced by the shipped API server.
+- Do not expose the API publicly without external authn/authz and network controls.
+
+## Low-risk evaluator route set
+
+Start with this allowlist during onboarding:
+
+| Route | Why start here |
+|-------|----------------|
+| `GET /health` | Process liveness |
+| `GET /ready` | Kubernetes + TrueNAS connectivity |
+| `GET /api/v1/orphans` | Primary implemented orphan correlation |
+| `GET /api/v1/orphans/pvs` | Implemented orphan PV subset |
+| `GET /api/v1/resources/pvs` | Implemented Kubernetes PV inventory |
+| `GET /api/v1/truenas/volumes` | Implemented TrueNAS volume inventory |
+| `GET /api/v1/validate` | Implemented connectivity validation |
+
+Routes outside this set may return HTTP 501 by design in the current baseline.
+
 ## Infrastructure
 
 | Route | Status | Notes |

--- a/docs/config-compatibility.md
+++ b/docs/config-compatibility.md
@@ -2,6 +2,17 @@
 
 Go services and the Python library/CLI use **different YAML schemas**. A single config file is not portable without translation.
 
+## Quick runtime decision (use this first)
+
+- Running `bin/api-server` or `bin/monitor`: use [`config.go.example`](../config.go.example) with `kubernetes:` + `truenas:`.
+- Running Python library/CLI: use [`config.yaml.example`](../config.yaml.example) with `openshift:` + `monitoring:`.
+- Production orphan checks in current baseline: prefer Go API routes (`/api/v1/orphans`, `/api/v1/orphans/pvs`).
+
+Safety note:
+
+- Go `security:` keys are parsed by `go/pkg/config` but are **not enforced** by the shipped API server or monitor.
+- Keep API exposure internal-only unless protected externally by your platform controls.
+
 ## Which file to use
 
 | Runtime | Example | Required top-level keys |

--- a/docs/onboarding/local-evaluator.md
+++ b/docs/onboarding/local-evaluator.md
@@ -1,0 +1,102 @@
+# Local evaluator onboarding (appendix)
+
+Use this path to evaluate behavior locally before or alongside in-cluster deployment.
+
+This guide focuses on low-risk checks and implemented surfaces only.
+
+## Scope and boundaries
+
+- Primary local target is the **Go API server** and optional **Go monitor**.
+- Python CLI commands exist, but several remain scaffold/demo outputs.
+- Do not treat local output as an authorization to perform destructive storage changes.
+
+## Choose the right config file first
+
+Go and Python use different schemas:
+
+- Go API/monitor: `config.go.example` (`kubernetes:` + `truenas:`)
+- Python library/CLI: `config.yaml.example` (`openshift:` + `monitoring:`)
+
+If your goal is production-grade orphan checks today, use the Go API path.
+See [config compatibility](../config-compatibility.md).
+
+## Prerequisites
+
+- Go 1.25.0+
+- Access to a non-production cluster (or controlled test context)
+- Reachable TrueNAS endpoint with valid credentials
+
+## Build binaries
+
+```bash
+make go-build
+```
+
+Expected binaries:
+
+- `bin/api-server`
+- `bin/monitor`
+
+## Configure environment
+
+Use environment variables for secrets:
+
+```bash
+export TRUENAS_USERNAME='service-account-name'
+export TRUENAS_PASSWORD='replace-me'
+```
+
+Avoid shell history leakage in shared environments (use secure secret injection when possible).
+
+## Run local API server
+
+```bash
+./bin/api-server -config config.go.example -port 8080
+```
+
+In another terminal:
+
+```bash
+curl -sS http://127.0.0.1:8080/health
+curl -sS http://127.0.0.1:8080/ready
+curl -sS http://127.0.0.1:8080/api/v1/orphans
+curl -sS http://127.0.0.1:8080/api/v1/orphans/pvs
+curl -sS http://127.0.0.1:8080/api/v1/resources/pvs
+curl -sS http://127.0.0.1:8080/api/v1/truenas/volumes
+curl -sS http://127.0.0.1:8080/api/v1/validate
+```
+
+## Optional: run local monitor
+
+```bash
+./bin/monitor -config config.go.example
+```
+
+Observe logs and metrics exposure based on your config (`metrics.enabled`, `metrics.port`, `metrics.path`).
+
+## Expected route behavior during local evaluation
+
+- Implemented endpoints return normal payloads.
+- Many roadmap endpoints return HTTP 501.
+- 501 is expected for unimplemented routes and indicates maturity boundaries, not runtime instability.
+
+Full route matrix: [api-endpoints.md](../api-endpoints.md).
+
+## Python CLI caveat (important)
+
+`truenas-monitor` command group is present, but several commands still return scaffold/demo output in baseline.
+
+For real orphan signal in current baseline, prefer:
+
+- Go API: `GET /api/v1/orphans`
+- Go API: `GET /api/v1/orphans/pvs`
+
+## Common local failure signatures
+
+- `/ready` fails: check Kubernetes context and TrueNAS reachability/credentials.
+- TLS failures to TrueNAS: verify CA trust; keep `insecure` disabled outside lab-only tests.
+- Empty or unexpected payloads: verify namespace and age-threshold assumptions in config.
+
+## Next step
+
+When local checks are stable, follow [operator-first.md](operator-first.md) for controlled in-cluster onboarding and rollout guardrails.

--- a/docs/onboarding/operator-first.md
+++ b/docs/onboarding/operator-first.md
@@ -1,0 +1,156 @@
+# Operator-first onboarding (low risk)
+
+This guide is the safest path to evaluate the project in a cluster.
+
+It is intentionally conservative:
+
+- Use a non-production cluster first.
+- Keep API exposure internal-only.
+- Use implemented routes only.
+- Do not perform destructive cleanup based only on first-pass findings.
+
+For product maturity context, see [PRD baseline](../PRD.md#2-current-baseline-shipped-now) and [API endpoint maturity](../api-endpoints.md).
+
+## Safety boundaries
+
+- Treat this tool as **read-oriented monitoring** for onboarding.
+- Keep both services as `ClusterIP` only during evaluation.
+- Keep TLS verification enabled for TrueNAS (`truenas.insecure: false`).
+- Use a least-privilege TrueNAS service account where possible.
+- Avoid public ingress/route/load balancer exposure for the API until your own auth and network controls are in place.
+
+## Prerequisites
+
+- Non-production Kubernetes/OpenShift cluster with democratic-csi.
+- Access to create resources in `truenas-monitor` namespace.
+- Access to create cluster-scoped RBAC objects (`ClusterRole`, `ClusterRoleBinding`).
+- Reachable TrueNAS endpoint and credentials for a scoped service account.
+- Container images built/pushed and pinned to immutable tags or digests.
+
+## Preflight checklist (before apply)
+
+1. Confirm context points to intended non-production cluster:
+
+```bash
+kubectl config current-context
+kubectl get ns
+```
+
+2. Validate manifests server-side:
+
+```bash
+kubectl apply --dry-run=server -f deploy/kubernetes/
+kubectl diff -f deploy/kubernetes/
+```
+
+3. Validate expected RBAC verbs for the service account:
+
+```bash
+kubectl auth can-i --as=system:serviceaccount:truenas-monitor:truenas-monitor list persistentvolumes
+kubectl auth can-i --as=system:serviceaccount:truenas-monitor:truenas-monitor list volumesnapshots.snapshot.storage.k8s.io
+kubectl auth can-i --as=system:serviceaccount:truenas-monitor:truenas-monitor list storageclasses.storage.k8s.io
+```
+
+4. Edit secret placeholders and verify no defaults remain:
+
+- Update `deploy/kubernetes/secret.yaml`:
+  - `TRUENAS_URL`
+  - `TRUENAS_USERNAME`
+  - `TRUENAS_PASSWORD`
+  - Optional `SLACK_WEBHOOK`
+- Never apply with default credentials such as `TRUENAS_PASSWORD: "changeme"` or `TRUENAS_USERNAME: "admin"`.
+- Generate unique credentials and inject them via secure secret-management workflows.
+- Treat `SLACK_WEBHOOK` as sensitive; set it only when needed and never commit real webhook values.
+
+5. Review config and deployment defaults:
+
+- `deploy/kubernetes/configmap.yaml`:
+  - Verify `kubernetes.namespace` matches your democratic-csi namespace.
+  - Keep `truenas.insecure` disabled (commented).
+- `deploy/kubernetes/monitor-deployment.yaml` and `deploy/kubernetes/api-deployment.yaml`:
+  - Replace `:latest` images with pinned tags/digests.
+- `deploy/kubernetes/services.yaml`:
+  - Keep `type: ClusterIP` during onboarding.
+
+## Deploy sequence
+
+Apply baseline manifests:
+
+```bash
+kubectl apply -f deploy/kubernetes/
+```
+
+Confirm resources are up:
+
+```bash
+kubectl -n truenas-monitor get pods,svc,cm,secret
+kubectl -n truenas-monitor get deploy
+```
+
+Check logs for startup and connectivity errors:
+
+```bash
+kubectl -n truenas-monitor logs deploy/truenas-monitor --tail=200
+kubectl -n truenas-monitor logs deploy/truenas-api --tail=200
+```
+
+## Verify implemented API routes only
+
+Port-forward API service:
+
+```bash
+kubectl -n truenas-monitor port-forward svc/truenas-api 8080:8080
+```
+
+In another shell, run smoke checks:
+
+```bash
+curl -sS http://127.0.0.1:8080/health
+curl -sS http://127.0.0.1:8080/ready
+curl -sS http://127.0.0.1:8080/api/v1/orphans
+curl -sS http://127.0.0.1:8080/api/v1/orphans/pvs
+curl -sS http://127.0.0.1:8080/api/v1/resources/pvs
+curl -sS http://127.0.0.1:8080/api/v1/truenas/volumes
+curl -sS http://127.0.0.1:8080/api/v1/validate
+```
+
+Expected onboarding behavior:
+
+- Implemented routes return normal JSON payloads.
+- Non-implemented routes return HTTP 501 with `{"error":"not_implemented", ...}`.
+
+## Triage and safe interpretation
+
+- Treat orphan findings as investigation leads, not immediate delete actions.
+- Validate each candidate against workload ownership and recent lifecycle events.
+- Use `age_threshold` query tuning to reduce noise during first runs.
+- Record findings and decision rationale before manual cleanup.
+
+## Stop conditions
+
+Stop and fix configuration if any of these occur:
+
+- `/ready` fails repeatedly after pods become ready.
+- Startup logs show TrueNAS auth or TLS verification failures.
+- API responses are mostly errors/timeouts instead of data/501 contracts.
+- Cluster policy/security review flags cluster-scope RBAC as unacceptable.
+
+## Rollback
+
+If onboarding needs to be rolled back:
+
+```bash
+kubectl delete -f deploy/kubernetes/
+```
+
+Then verify namespace and cluster objects are removed or intentionally retained:
+
+```bash
+kubectl get clusterrole truenas-monitor
+kubectl get clusterrolebinding truenas-monitor
+kubectl get ns truenas-monitor
+```
+
+## Next step
+
+After operator onboarding is stable, use the local evaluation path in [local-evaluator.md](local-evaluator.md) for iterative diagnostics and development.

--- a/docs/onboarding/operator-first.md
+++ b/docs/onboarding/operator-first.md
@@ -43,15 +43,7 @@ kubectl apply --dry-run=server -f deploy/kubernetes/
 kubectl diff -f deploy/kubernetes/
 ```
 
-3. Validate expected RBAC verbs for the service account:
-
-```bash
-kubectl auth can-i --as=system:serviceaccount:truenas-monitor:truenas-monitor list persistentvolumes
-kubectl auth can-i --as=system:serviceaccount:truenas-monitor:truenas-monitor list volumesnapshots.snapshot.storage.k8s.io
-kubectl auth can-i --as=system:serviceaccount:truenas-monitor:truenas-monitor list storageclasses.storage.k8s.io
-```
-
-4. Edit secret placeholders and verify no defaults remain:
+3. Edit secret placeholders and verify no defaults remain:
 
 - Update `deploy/kubernetes/secret.yaml`:
   - `TRUENAS_URL`
@@ -62,13 +54,13 @@ kubectl auth can-i --as=system:serviceaccount:truenas-monitor:truenas-monitor li
 - Generate unique credentials and inject them via secure secret-management workflows.
 - Treat `SLACK_WEBHOOK` as sensitive; set it only when needed and never commit real webhook values.
 
-5. Review config and deployment defaults:
+4. Review config and deployment defaults:
 
 - `deploy/kubernetes/configmap.yaml`:
   - Verify `kubernetes.namespace` matches your democratic-csi namespace.
   - Keep `truenas.insecure` disabled (commented).
 - `deploy/kubernetes/monitor-deployment.yaml` and `deploy/kubernetes/api-deployment.yaml`:
-  - Replace `:latest` images with pinned tags/digests.
+  - Replace `:latest` image references with immutable tags or digests (do not rely on floating `:latest` in production).
 - `deploy/kubernetes/services.yaml`:
   - Keep `type: ClusterIP` during onboarding.
 
@@ -93,6 +85,21 @@ Check logs for startup and connectivity errors:
 kubectl -n truenas-monitor logs deploy/truenas-monitor --tail=200
 kubectl -n truenas-monitor logs deploy/truenas-api --tail=200
 ```
+
+## Post-deploy RBAC verification
+
+Run these **after** `kubectl apply` so the ServiceAccount and bindings exist. Set `CSI_NAMESPACE` to match `kubernetes.namespace` in the ConfigMap (default in manifests: `democratic-csi`).
+
+```bash
+SA=system:serviceaccount:truenas-monitor:truenas-monitor
+CSI_NAMESPACE=democratic-csi
+
+kubectl auth can-i --as="$SA" list persistentvolumes
+kubectl auth can-i --as="$SA" list storageclasses.storage.k8s.io
+kubectl auth can-i --as="$SA" -n "$CSI_NAMESPACE" list volumesnapshots.snapshot.storage.k8s.io
+```
+
+If any check returns `no`, inspect `deploy/kubernetes/rbac.yaml` and your cluster policy before relying on monitor/API results.
 
 ## Verify implemented API routes only
 


### PR DESCRIPTION
## Summary
- add operator-first onboarding runbook with preflight, safe deploy, verification, stop conditions, and rollback steps
- add local evaluator onboarding appendix with Go-vs-Python config decision guidance and implemented-route smoke checks
- tighten README, API endpoint maturity, config compatibility, and architecture docs with explicit baseline safety/maturity boundaries

## Test plan
- [x] Review docs for implemented-vs-planned consistency against `docs/api-endpoints.md` and `docs/PRD.md`
- [x] Verify onboarding paths and file links resolve in repository
- [x] Run pre-commit and pre-push CodeRabbit review passes (`coderabbit review --prompt-only`) with zero findings

## Mandatory PR Checklist
- [x] **Scope:** Maps to one plan item (or approved exception documented).
- [ ] **Correctness:** Added/updated tests for changed logic. (Docs-only change; no logic changed)
- [ ] **Regression Safety:** Relevant existing tests pass. (Docs-only change)
- [ ] **CI:** All required GitHub Actions checks green on the PR head commit.
- [x] **Security:** No insecure defaults introduced; secrets not exposed.
- [x] **Reliability:** Failure paths handled; retries/timeouts/backoff are sane.
- [x] **Performance:** No obvious unbounded loops/maps or avoidable N^2 regressions.
- [x] **Docs:** Updated README/docs/config examples if behavior changed.
- [x] **Ops/Runbook:** Added migration/rollout notes when operational behavior changes.
- [x] **Verification Evidence:** Commands run and results captured in PR notes.
- [ ] **Tracking:** Plan status/checklists and PR URL updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a “Start here (low-risk)” onboarding path with explicit safety/maturity guardrails
  * Clarified shipped behavior vs. roadmap and pointed to shipped sections as the source of truth
  * Bumped documented Go runtime requirement to 1.25.0+
  * Added pre-deployment checklist and Kubernetes manifest safety guidance
  * New local-evaluation and operator-first cluster onboarding guides
  * Added API onboarding notes and a low-risk evaluator route set; clarified config/runtime expectations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->